### PR TITLE
Obtain bulk_flush_interval from route options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ If you have issues, then run all lints and check consistency.
 
     ```shell
     pipenv run fmt
-    pipenv isort-fmt
+    pipenv run isort-fmt
     pipenv run lint
 
     ```

--- a/asyncworker/conf.py
+++ b/asyncworker/conf.py
@@ -3,6 +3,8 @@ import logging
 from aiologger.loggers.json import JsonLogger
 from pydantic import BaseSettings
 
+from asyncworker.options import DefaultValues
+
 
 class Settings(BaseSettings):
     LOGLEVEL: str = "ERROR"
@@ -13,6 +15,8 @@ class Settings(BaseSettings):
 
     HTTP_HOST: str = "127.0.0.1"
     HTTP_PORT: int = 8080
+
+    FLUSH_TIMEOUT: int = DefaultValues.BULK_FLUSH_INTERVAL
 
     class Config:
         allow_mutation = False

--- a/asyncworker/conf.py
+++ b/asyncworker/conf.py
@@ -14,8 +14,6 @@ class Settings(BaseSettings):
     HTTP_HOST: str = "127.0.0.1"
     HTTP_PORT: int = 8080
 
-    FLUSH_TIMEOUT: int = 60
-
     class Config:
         allow_mutation = False
         env_prefix = "ASYNCWORKER_"

--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -7,7 +7,7 @@ from aioamqp.exceptions import AioamqpException
 from asyncworker import conf
 from asyncworker.easyqueue.message import AMQPMessage
 from asyncworker.easyqueue.queue import JsonQueue, QueueConsumerDelegate
-from asyncworker.options import Events
+from asyncworker.options import DefaultValues, Events, Options
 from asyncworker.routes import AMQPRoute
 from asyncworker.time import ClockTicker
 
@@ -44,7 +44,11 @@ class Consumer(QueueConsumerDelegate):
             delegate=self,
             prefetch_count=prefetch_count,
         )
-        self.clock = ClockTicker(seconds=conf.settings.FLUSH_TIMEOUT)
+        self.clock = ClockTicker(
+            seconds=self._route_options.get(
+                Options.BULK_FLUSH_INTERVAL, DefaultValues.BULK_FLUSH_INTERVAL
+            )
+        )
         self.clock_task = None
 
     @property

--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -7,7 +7,7 @@ from aioamqp.exceptions import AioamqpException
 from asyncworker import conf
 from asyncworker.easyqueue.message import AMQPMessage
 from asyncworker.easyqueue.queue import JsonQueue, QueueConsumerDelegate
-from asyncworker.options import DefaultValues, Events, Options
+from asyncworker.options import Events, Options
 from asyncworker.routes import AMQPRoute
 from asyncworker.time import ClockTicker
 
@@ -46,7 +46,7 @@ class Consumer(QueueConsumerDelegate):
         )
         self.clock = ClockTicker(
             seconds=self._route_options.get(
-                Options.BULK_FLUSH_INTERVAL, DefaultValues.BULK_FLUSH_INTERVAL
+                Options.BULK_FLUSH_INTERVAL, conf.settings.FLUSH_TIMEOUT
             )
         )
         self.clock_task = None

--- a/docs-src/userguide/handlers/rabbitmq.rst
+++ b/docs-src/userguide/handlers/rabbitmq.rst
@@ -126,7 +126,10 @@ Por exemplo, se tivermos um ``handler`` que possui:
 
 Nesse caso a ``app`` irá esperar o timeout do flush para liberar essas mensagens para o ``handler``.
 
-Caso queria alterar o tempo default do timeout do flush basta definir env ``ASYNCWORKER_FLUSH_TIMEOUT`` com um número que representará os segundos em que a app irá esperar para realizar o flush
+Caso queira alterar o tempo default do timeout do flush basta definir env ``ASYNCWORKER_FLUSH_TIMEOUT`` com um número que representará os segundos em que a app irá esperar para realizar o flush.
+
+Também é possível alterar o tempo do timeout do flush definindo o campo ``Options.BULK_FLUSH_INTERVAL`` do dicionário ``options`` passado como parâmetro na criação da rota.
+O valor passado para o dicionário ``options`` tem precedência sobre a variável de ambiente ``ASYNCWORKER_FLUSH_TIMEOUT``.
 
 
 

--- a/docs/userguide/handlers/rabbitmq.html
+++ b/docs/userguide/handlers/rabbitmq.html
@@ -141,7 +141,9 @@ Por exemplo, se tivermos um <code class="docutils literal notranslate"><span cla
 </ul>
 </div></blockquote>
 <p>Nesse caso a <code class="docutils literal notranslate"><span class="pre">app</span></code> irá esperar o timeout do flush para liberar essas mensagens para o <code class="docutils literal notranslate"><span class="pre">handler</span></code>.</p>
-<p>Caso queria alterar o tempo default do timeout do flush basta definir env <code class="docutils literal notranslate"><span class="pre">ASYNCWORKER_FLUSH_TIMEOUT</span></code> com um número que representará os segundos em que a app irá esperar para realizar o flush</p>
+<p>Caso queira alterar o tempo default do timeout do flush basta definir env <code class="docutils literal notranslate"><span class="pre">ASYNCWORKER_FLUSH_TIMEOUT</span></code> com um número que representará os segundos em que a app irá esperar para realizar o flush.</p>
+<p>Também é possível alterar o tempo do timeout do flush definindo o campo <code class="docutils literal notranslate"><span class="pre">Options.BULK_FLUSH_INTERVAL</span></code> do dicionário <code class="docutils literal notranslate"><span class="pre">options</span></code> passado como parâmetro na criação da rota.
+O valor passado para o dicionário <code class="docutils literal notranslate"><span class="pre">options</span></code> tem precedência sobre a variável de ambiente <code class="docutils literal notranslate"><span class="pre">ASYNCWORKER_FLUSH_TIMEOUT</span></code>.</p>
 </div>
 <div class="section" id="exemplo-de-um-codigo-mais-completo">
 <h3>Exemplo de um código mais completo<a class="headerlink" href="#exemplo-de-um-codigo-mais-completo" title="Link permanente para este título">¶</a></h3>

--- a/tests/rabbitmq/test_rabbitmq_consumer.py
+++ b/tests/rabbitmq/test_rabbitmq_consumer.py
@@ -35,7 +35,7 @@ class ConsumerTest(asynctest.TestCase):
             "vhost": "/",
             "options": {
                 "bulk_size": 1,
-                "bulk_flush_interval": 60,
+                "bulk_flush_interval": 1,
                 Events.ON_SUCCESS: Actions.ACK,
                 Events.ON_EXCEPTION: Actions.REQUEUE,
             },
@@ -485,6 +485,7 @@ class ConsumerTest(asynctest.TestCase):
 
         self.one_route_fixture["handler"] = handler
         self.one_route_fixture["options"]["bulk_size"] = 3
+        self.one_route_fixture["options"]["bulk_flush_interval"] = 0.1
 
         consumer = Consumer(
             self.one_route_fixture,


### PR DESCRIPTION
O bulk_flush_interval estava sendo pego do arquivo de configuração ao invés da configuração da rota. Fiz a modificação para pegar da configuração da rota (passado no app.route), como está na documentação.