### PR TITLE
Callback chamada caso haja erro na conexão com broker

### DIFF
--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -43,6 +43,7 @@ class Consumer(QueueConsumerDelegate):
             virtual_host=self.vhost,
             delegate=self,
             prefetch_count=prefetch_count,
+            logger=conf.logger,
             connection_fail_handler=self._route_options.get(
                 Options.CONNECTION_FAIL_HANDLER, None
             ),

--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -44,8 +44,8 @@ class Consumer(QueueConsumerDelegate):
             delegate=self,
             prefetch_count=prefetch_count,
             logger=conf.logger,
-            connection_fail_handler=self._route_options.get(
-                Options.CONNECTION_FAIL_HANDLER, None
+            connection_fail_callback=self._route_options.get(
+                Options.CONNECTION_FAIL_CALLBACK, None
             ),
         )
         self.clock = ClockTicker(

--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -7,7 +7,7 @@ from aioamqp.exceptions import AioamqpException
 from asyncworker import conf
 from asyncworker.easyqueue.message import AMQPMessage
 from asyncworker.easyqueue.queue import JsonQueue, QueueConsumerDelegate
-from asyncworker.options import Events, Options
+from asyncworker.options import DefaultValues, Events, Options
 from asyncworker.routes import AMQPRoute
 from asyncworker.time import ClockTicker
 
@@ -43,6 +43,9 @@ class Consumer(QueueConsumerDelegate):
             virtual_host=self.vhost,
             delegate=self,
             prefetch_count=prefetch_count,
+            connection_fail_handler=self._route_options.get(
+                Options.CONNECTION_FAIL_HANDLER, None
+            ),
         )
         self.clock = ClockTicker(
             seconds=self._route_options.get(

--- a/asyncworker/easyqueue/queue.py
+++ b/asyncworker/easyqueue/queue.py
@@ -91,6 +91,8 @@ def _ensure_connected(coro: Callable[..., Coroutine]):
             except Exception as e:
                 await asyncio.sleep(self.seconds_between_conn_retry)
                 retries += 1
+                if self.connection_fail_handler:
+                    await self.connection_fail_handler(e, retries)
                 if self.logger:
                     self.logger.error(
                         {
@@ -181,6 +183,9 @@ class JsonQueue(BaseQueue, Generic[T]):
         loop: AbstractEventLoop = None,
         seconds_between_conn_retry: int = 1,
         logger: logging.Logger = None,
+        connection_fail_handler: Optional[
+            Callable[[Exception, int], Coroutine]
+        ] = None,
     ) -> None:
         super().__init__(host, username, password, virtual_host, heartbeat)
 
@@ -216,6 +221,7 @@ class JsonQueue(BaseQueue, Generic[T]):
         self.seconds_between_conn_retry = seconds_between_conn_retry
         self.is_running = True
         self.logger = logger
+        self.connection_fail_handler = connection_fail_handler
 
     def serialize(self, body: T, **kwargs) -> str:
         return json.dumps(body, **kwargs)

--- a/asyncworker/easyqueue/queue.py
+++ b/asyncworker/easyqueue/queue.py
@@ -91,8 +91,8 @@ def _ensure_connected(coro: Callable[..., Coroutine]):
             except Exception as e:
                 await asyncio.sleep(self.seconds_between_conn_retry)
                 retries += 1
-                if self.connection_fail_handler:
-                    await self.connection_fail_handler(e, retries)
+                if self.connection_fail_callback:
+                    await self.connection_fail_callback(e, retries)
                 if self.logger:
                     self.logger.error(
                         {
@@ -183,7 +183,7 @@ class JsonQueue(BaseQueue, Generic[T]):
         loop: AbstractEventLoop = None,
         seconds_between_conn_retry: int = 1,
         logger: logging.Logger = None,
-        connection_fail_handler: Optional[
+        connection_fail_callback: Optional[
             Callable[[Exception, int], Coroutine]
         ] = None,
     ) -> None:
@@ -221,7 +221,7 @@ class JsonQueue(BaseQueue, Generic[T]):
         self.seconds_between_conn_retry = seconds_between_conn_retry
         self.is_running = True
         self.logger = logger
-        self.connection_fail_handler = connection_fail_handler
+        self.connection_fail_callback = connection_fail_callback
 
     def serialize(self, body: T, **kwargs) -> str:
         return json.dumps(body, **kwargs)

--- a/asyncworker/options.py
+++ b/asyncworker/options.py
@@ -13,7 +13,7 @@ class Options(AutoNameEnum):
     BULK_SIZE = auto()
     BULK_FLUSH_INTERVAL = auto()
     MAX_CONCURRENCY = auto()
-    CONNECTION_FAIL_HANDLER = auto()
+    CONNECTION_FAIL_CALLBACK = auto()
 
 
 class Actions(AutoNameEnum):

--- a/asyncworker/options.py
+++ b/asyncworker/options.py
@@ -13,6 +13,7 @@ class Options(AutoNameEnum):
     BULK_SIZE = auto()
     BULK_FLUSH_INTERVAL = auto()
     MAX_CONCURRENCY = auto()
+    CONNECTION_FAIL_HANDLER = auto()
 
 
 class Actions(AutoNameEnum):

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -122,7 +122,7 @@ class _AMQPRouteOptions(_RouteOptions):
     bulk_flush_interval: int = DefaultValues.BULK_FLUSH_INTERVAL
     on_success: Actions = DefaultValues.ON_SUCCESS
     on_exception: Actions = DefaultValues.ON_EXCEPTION
-    connection_fail_handler: Optional[
+    connection_fail_callback: Optional[
         Callable[[Exception, int], Coroutine]
     ] = None
     connection: Optional[Union[AMQPConnection, str]]

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -122,6 +122,9 @@ class _AMQPRouteOptions(_RouteOptions):
     bulk_flush_interval: int = DefaultValues.BULK_FLUSH_INTERVAL
     on_success: Actions = DefaultValues.ON_SUCCESS
     on_exception: Actions = DefaultValues.ON_EXCEPTION
+    connection_fail_handler: Optional[
+        Callable[[Exception, int], Coroutine]
+    ] = None
     connection: Optional[Union[AMQPConnection, str]]
 
     class Config:

--- a/docs-src/userguide/handlers/rabbitmq.rst
+++ b/docs-src/userguide/handlers/rabbitmq.rst
@@ -83,6 +83,7 @@ o dicionário ``options`` pode ter as seguintes chaves:
 
   - :py:attr:`Options.BULK_SIZE <asyncworker.options.Options.BULK_SIZE>`: Esse valor é um inteiro e diz qual será o tamanho máximo da lista que o handler vai receber, a cada vez que for chamado.
   - :py:attr:`Options.BULK_FLUSH_INTERVAL <asyncworker.options.Options.BULK_FLUSH_INTERVAL>`: Inteiro e diz o tempo máximo que o bulk de mensagens poderá ficar com tamanho menor do que ``bulk_size``. Exemplo: Se seu handler tem um bulk_size de 4096 mensagens mas você recebe apenas 100 msg/min na fila em alguns momentos seu handler será chamado recebendo uma lista de mensagens **menor** do que 4096.
+  - :py:attr:`Options.CONNECTION_FAIL_HANDLER <asyncworker.options.Options.CONNECTION_FAIL_HANDLER>`: Função assíncrona que é chamada caso haja uma falha durante a conexão com o broker. Essa função recebe a exceção que ocorreu e o número de retentativas que falharam até então. O número de retentativas é zerado quando o app consegue se conectar com o broker.
   - :py:attr:`Events.ON_SUCCESS <asyncworker.options.Events.ON_SUCCESS>`: Diz qual será a ação tomada pelo asyncworker quando uma chamada a um handler for concluída com sucesso, ou seja, o handler não lançar nenhuma exception. O Valor padrão é :py:attr:`Actions.ACK <asyncworker.options.Actions.ACK>`
   - :py:attr:`Events.ON_EXCEPTION <asyncworker.options.Events.ON_EXCEPTION>`: Diz qual será a ação padrão quando a chamada a um handler lançar uma excação não tratada. O valor padrão é :py:attr:`Actions.REQUEUE <asyncworker.options.Actions.REQUEUE>`
 
@@ -94,11 +95,15 @@ Exemplo de um código que usa essas opções:
   from asyncworker import App
   from asyncworker.options import Options, Actions, Events
 
+  async def fail_handler(e: Exception, n: int):
+      print(f"error: {e}, retries {n}")
+
   @app.route(
       ["queue"],
       options={
           Options.BULK_SIZE: 1000,
           Options.BULK_FLUSH_INTERVAL: 60,
+          Options.CONNECTION_FAIL_HANDLER: fail_handler,
           Events.ON_SUCCESS: Actions.ACK,
           Events.ON_EXCEPTION: Actions.REJECT,
       },

--- a/docs-src/userguide/handlers/rabbitmq.rst
+++ b/docs-src/userguide/handlers/rabbitmq.rst
@@ -83,7 +83,7 @@ o dicionário ``options`` pode ter as seguintes chaves:
 
   - :py:attr:`Options.BULK_SIZE <asyncworker.options.Options.BULK_SIZE>`: Esse valor é um inteiro e diz qual será o tamanho máximo da lista que o handler vai receber, a cada vez que for chamado.
   - :py:attr:`Options.BULK_FLUSH_INTERVAL <asyncworker.options.Options.BULK_FLUSH_INTERVAL>`: Inteiro e diz o tempo máximo que o bulk de mensagens poderá ficar com tamanho menor do que ``bulk_size``. Exemplo: Se seu handler tem um bulk_size de 4096 mensagens mas você recebe apenas 100 msg/min na fila em alguns momentos seu handler será chamado recebendo uma lista de mensagens **menor** do que 4096.
-  - :py:attr:`Options.CONNECTION_FAIL_HANDLER <asyncworker.options.Options.CONNECTION_FAIL_HANDLER>`: Função assíncrona que é chamada caso haja uma falha durante a conexão com o broker. Essa função recebe a exceção que ocorreu e o número de retentativas que falharam até então. O número de retentativas é zerado quando o app consegue se conectar com o broker.
+  - :py:attr:`Options.CONNECTION_FAIL_CALLBACK <asyncworker.options.Options.CONNECTION_FAIL_CALLBACK>`: Função assíncrona que é chamada caso haja uma falha durante a conexão com o broker. Essa função recebe a exceção que ocorreu e o número de retentativas que falharam até então. O número de retentativas é zerado quando o app consegue se conectar com o broker.
   - :py:attr:`Events.ON_SUCCESS <asyncworker.options.Events.ON_SUCCESS>`: Diz qual será a ação tomada pelo asyncworker quando uma chamada a um handler for concluída com sucesso, ou seja, o handler não lançar nenhuma exception. O Valor padrão é :py:attr:`Actions.ACK <asyncworker.options.Actions.ACK>`
   - :py:attr:`Events.ON_EXCEPTION <asyncworker.options.Events.ON_EXCEPTION>`: Diz qual será a ação padrão quando a chamada a um handler lançar uma excação não tratada. O valor padrão é :py:attr:`Actions.REQUEUE <asyncworker.options.Actions.REQUEUE>`
 
@@ -103,7 +103,7 @@ Exemplo de um código que usa essas opções:
       options={
           Options.BULK_SIZE: 1000,
           Options.BULK_FLUSH_INTERVAL: 60,
-          Options.CONNECTION_FAIL_HANDLER: fail_handler,
+          Options.CONNECTION_FAIL_CALLBACK: fail_handler,
           Events.ON_SUCCESS: Actions.ACK,
           Events.ON_EXCEPTION: Actions.REJECT,
       },

--- a/tests/easyqueue/test_async_queue.py
+++ b/tests/easyqueue/test_async_queue.py
@@ -606,7 +606,7 @@ class EnsureConnectedDecoratorTests(asynctest.TestCase):
                 _connect=CoroutineMock(side_effect=[ConnectionError, True]),
             ),
             seconds_between_conn_retry=seconds,
-            connection_fail_handler=None,
+            connection_fail_callback=None,
         )
         coro = CoroutineMock()
         with asynctest.patch(
@@ -631,7 +631,7 @@ class EnsureConnectedDecoratorTests(asynctest.TestCase):
                 is_connected=False,
             ),
             logger=Mock(spec=logging.Logger),
-            connection_fail_handler=None,
+            connection_fail_callback=None,
         )
         coro = CoroutineMock()
         with asynctest.patch(
@@ -650,7 +650,7 @@ class EnsureConnectedDecoratorTests(asynctest.TestCase):
                 _connect=CoroutineMock(side_effect=[error, True]),
                 is_connected=False,
             ),
-            connection_fail_handler=CoroutineMock(),
+            connection_fail_callback=CoroutineMock(),
         )
         coro = CoroutineMock()
         with asynctest.patch(
@@ -659,4 +659,4 @@ class EnsureConnectedDecoratorTests(asynctest.TestCase):
             wrapped = _ensure_connected(coro)
             await wrapped(async_queue, 1, dog="Xablau")
 
-        async_queue.connection_fail_handler.assert_called_once_with(error, 1)
+        async_queue.connection_fail_callback.assert_called_once_with(error, 1)

--- a/tests/easyqueue/test_async_queue.py
+++ b/tests/easyqueue/test_async_queue.py
@@ -606,6 +606,7 @@ class EnsureConnectedDecoratorTests(asynctest.TestCase):
                 _connect=CoroutineMock(side_effect=[ConnectionError, True]),
             ),
             seconds_between_conn_retry=seconds,
+            connection_fail_handler=CoroutineMock(),
         )
         coro = CoroutineMock()
         with asynctest.patch(
@@ -630,6 +631,7 @@ class EnsureConnectedDecoratorTests(asynctest.TestCase):
                 is_connected=False,
             ),
             logger=Mock(spec=logging.Logger),
+            connection_fail_handler=CoroutineMock(),
         )
         coro = CoroutineMock()
         with asynctest.patch(

--- a/tests/easyqueue/test_async_queue.py
+++ b/tests/easyqueue/test_async_queue.py
@@ -659,4 +659,4 @@ class EnsureConnectedDecoratorTests(asynctest.TestCase):
             wrapped = _ensure_connected(coro)
             await wrapped(async_queue, 1, dog="Xablau")
 
-        async_queue.connection_fail_callback.assert_called_once_with(error, 1)
+        async_queue.connection_fail_callback.assert_awaited_once_with(error, 1)


### PR DESCRIPTION
Estava precisando de uma callback que fosse chamada quando a conexão com o broker falhasse.
Adicionei uma nova opção lá no `_AMQPRouteOptions` e adicionei a chamada à função no `JsonQueue`.
Além disso, habilitei o log caso haja error de conexão no `JsonQueue`; a variável de log não estava definida.