### PR TITLE
Não remove / à esquerda dos vhosts

### DIFF
--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -31,8 +31,6 @@ class Consumer(QueueConsumerDelegate):
         self._route_options = route_info["options"]
         self.host = host
         self.vhost = route_info.get("vhost", "/")
-        if self.vhost != "/":
-            self.vhost = self.vhost.lstrip("/")
         self.bucket = bucket_class(
             size=min(self._route_options["bulk_size"], prefetch_count)
         )

--- a/tests/rabbitmq/test_rabbitmq_consumer.py
+++ b/tests/rabbitmq/test_rabbitmq_consumer.py
@@ -129,13 +129,15 @@ class ConsumerTest(asynctest.TestCase):
         self.assertTrue(isinstance(consumer.queue, JsonQueue))
         self.assertEqual("fluentd", connection_parameters["virtualhost"])
 
-    def test_consumer_instantiate_async_queue_other_vhost_strip_slash(self):
+    def test_consumer_instantiate_async_queue_other_vhost_does_not_strip_slash(
+        self
+    ):
         self.one_route_fixture["vhost"] = "/fluentd"
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         connection_parameters = consumer.queue.connection.connection_parameters
 
         self.assertTrue(isinstance(consumer.queue, JsonQueue))
-        self.assertEqual("fluentd", connection_parameters["virtualhost"])
+        self.assertEqual("/fluentd", connection_parameters["virtualhost"])
 
     def test_consumer_instantiate_async_queue_prefetch_count(self):
         self.one_route_fixture["vhost"] = "/fluentd"
@@ -143,7 +145,7 @@ class ConsumerTest(asynctest.TestCase):
         connection_parameters = consumer.queue.connection.connection_parameters
 
         self.assertTrue(isinstance(consumer.queue, JsonQueue))
-        self.assertEqual("fluentd", connection_parameters["virtualhost"])
+        self.assertEqual("/fluentd", connection_parameters["virtualhost"])
         self.assertEqual(1024, consumer.queue.prefetch_count)
 
     def test_consumer_returns_correct_queue_name(self):


### PR DESCRIPTION
Tenho que acessar um vhost no formato `/bla`, mas o asyncworker remove os `/` à esquerda, então não consigo conectar no vhost correto, recebendo esse erro:

```
"(530, 'NOT_ALLOWED - vhost bla not found')"
```

Esse PR remove a lógica que remove o `/` do nome do vhost.