### PR TITLE
Associando as métricas ao nosso registry interno

### DIFF
--- a/asyncworker/conf.py
+++ b/asyncworker/conf.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
 
     # metrics
     METRICS_NAMESPACE: str = "asyncworker"
-    APPMETRICS_PREFIX: Optional[str]
+    METRICS_APPPREFIX: Optional[str]
     METRICS_HTTP_ROUTE_PATH: str = "/metrics"
     METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS: List[float] = [
         10,

--- a/asyncworker/conf.py
+++ b/asyncworker/conf.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import List
+from typing import Optional, List
 
 from aiologger.loggers.json import JsonLogger
 from pydantic import BaseSettings
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
 
     # metrics
     METRICS_NAMESPACE: str = "asyncworker"
+    APPMETRICS_PREFIX: Optional[str]
     METRICS_HTTP_ROUTE_PATH: str = "/metrics"
     METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS: List[float] = [
         10,

--- a/asyncworker/conf.py
+++ b/asyncworker/conf.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     FLUSH_TIMEOUT: int = DefaultValues.BULK_FLUSH_INTERVAL
 
     # metrics
+    METRICS_NAMESPACE: str = "asyncworker"
     METRICS_HTTP_ROUTE_PATH: str = "/metrics"
     METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS: List[float] = [
         10,

--- a/asyncworker/metrics/aiohttp_resources.py
+++ b/asyncworker/metrics/aiohttp_resources.py
@@ -5,11 +5,13 @@ from aiohttp.web_middlewares import middleware
 
 from asyncworker import metrics
 from asyncworker.conf import default_timer
-from asyncworker.metrics.registry import generate_latest
+from asyncworker.metrics.registry import generate_latest, REGISTRY
 
 _Handler = Callable[[web.Request], Awaitable[web.Response]]
 
 
 async def metrics_route_handler(request: web.Request) -> web.Response:
-    response = web.Response(body=generate_latest(), content_type="text/plain")
+    response = web.Response(
+        body=generate_latest(registry=REGISTRY), content_type="text/plain"
+    )
     return response

--- a/asyncworker/metrics/aiohttp_resources.py
+++ b/asyncworker/metrics/aiohttp_resources.py
@@ -1,16 +1,10 @@
-from typing import Callable, Awaitable
-
 from aiohttp import web
-from aiohttp.web_middlewares import middleware
+from prometheus_client import generate_latest
 
-from asyncworker import metrics
-from asyncworker.conf import default_timer
-from asyncworker.metrics.registry import generate_latest, REGISTRY
-
-_Handler = Callable[[web.Request], Awaitable[web.Response]]
+from asyncworker.metrics.registry import REGISTRY
 
 
-async def metrics_route_handler(request: web.Request) -> web.Response:
+async def metrics_route_handler() -> web.Response:
     response = web.Response(
         body=generate_latest(registry=REGISTRY), content_type="text/plain"
     )

--- a/asyncworker/metrics/collectors/base.py
+++ b/asyncworker/metrics/collectors/base.py
@@ -1,0 +1,10 @@
+import abc
+from typing import Iterable
+
+from prometheus_client import Metric
+
+
+class BaseCollector(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def collect(self) -> Iterable[Metric]:
+        """A method that returns a list of Metric objects"""

--- a/asyncworker/metrics/collectors/gc.py
+++ b/asyncworker/metrics/collectors/gc.py
@@ -1,13 +1,18 @@
 import gc
 import platform
 
+from prometheus_client import CollectorRegistry
 from prometheus_client.metrics_core import CounterMetricFamily
 
+from asyncworker.metrics.collectors.base import BaseCollector
 
-class GCCollector(object):
+
+class GCCollector(BaseCollector):
     """Collector for Garbage collection statistics."""
 
-    def __init__(self, registry, namespace=""):
+    def __init__(
+        self, registry: CollectorRegistry, namespace: str = ""
+    ) -> None:
         if (
             not hasattr(gc, "get_stats")
             or platform.python_implementation() != "CPython"

--- a/asyncworker/metrics/collectors/gc.py
+++ b/asyncworker/metrics/collectors/gc.py
@@ -1,0 +1,44 @@
+import gc
+import platform
+
+from prometheus_client.metrics_core import CounterMetricFamily
+
+
+class GCCollector(object):
+    """Collector for Garbage collection statistics."""
+
+    def __init__(self, registry, namespace=""):
+        if (
+            not hasattr(gc, "get_stats")
+            or platform.python_implementation() != "CPython"
+        ):
+            return
+        if namespace:
+            self.namespace = f"{namespace}_"
+        registry.register(self)
+
+    def collect(self):
+        collected = CounterMetricFamily(
+            f"{self.namespace}python_gc_objects_collected",
+            "Objects collected during gc",
+            labels=["generation"],
+        )
+        uncollectable = CounterMetricFamily(
+            f"{self.namespace}python_gc_objects_uncollectable",
+            "Uncollectable object found during GC",
+            labels=["generation"],
+        )
+
+        collections = CounterMetricFamily(
+            f"{self.namespace}python_gc_collections",
+            "Number of times this generation was collected",
+            labels=["generation"],
+        )
+
+        for generation, stat in enumerate(gc.get_stats()):
+            generation = str(generation)
+            collected.add_metric([generation], value=stat["collected"])
+            uncollectable.add_metric([generation], value=stat["uncollectable"])
+            collections.add_metric([generation], value=stat["collections"])
+
+        return [collected, uncollectable, collections]

--- a/asyncworker/metrics/collectors/platform.py
+++ b/asyncworker/metrics/collectors/platform.py
@@ -1,0 +1,59 @@
+import gc
+import platform as pf
+
+from prometheus_client.metrics_core import GaugeMetricFamily
+
+
+class PlatformCollector(object):
+    """Collector for python platform information"""
+
+    def __init__(self, registry, namespace=""):
+        self._platform = pf
+        info = self._info()
+        system = self._platform.system()
+        if system == "Java":
+            info.update(self._java())
+
+        if namespace:
+            self.namespace = f"{namespace}_"
+
+        self._metrics = [
+            self._add_metric(
+                f"{self.namespace}python_info",
+                "Python platform information",
+                info,
+            )
+        ]
+
+        registry.register(self)
+
+    def collect(self):
+        return self._metrics
+
+    @staticmethod
+    def _add_metric(name, documentation, data):
+        labels = data.keys()
+        values = [data[k] for k in labels]
+        g = GaugeMetricFamily(name, documentation, labels=labels)
+        g.add_metric(values, 1)
+        return g
+
+    def _info(self):
+        major, minor, patchlevel = self._platform.python_version_tuple()
+        return {
+            "version": self._platform.python_version(),
+            "implementation": self._platform.python_implementation(),
+            "major": major,
+            "minor": minor,
+            "patchlevel": patchlevel,
+        }
+
+    def _java(self):
+        java_version, _, vminfo, osinfo = self._platform.java_ver()
+        vm_name, vm_release, vm_vendor = vminfo
+        return {
+            "jvm_version": java_version,
+            "jvm_release": vm_release,
+            "jvm_vendor": vm_vendor,
+            "jvm_name": vm_name,
+        }

--- a/asyncworker/metrics/collectors/platform.py
+++ b/asyncworker/metrics/collectors/platform.py
@@ -1,16 +1,19 @@
-import gc
-import platform as pf
+import platform
 
+from prometheus_client import CollectorRegistry
 from prometheus_client.metrics_core import GaugeMetricFamily
 
+from asyncworker.metrics.collectors.base import BaseCollector
 
-class PlatformCollector(object):
+
+class PlatformCollector(BaseCollector):
     """Collector for python platform information"""
 
-    def __init__(self, registry, namespace=""):
-        self._platform = pf
+    def __init__(
+        self, registry: CollectorRegistry, namespace: str = ""
+    ) -> None:
         info = self._info()
-        system = self._platform.system()
+        system = platform.system()
         if system == "Java":
             info.update(self._java())
 
@@ -31,7 +34,9 @@ class PlatformCollector(object):
         return self._metrics
 
     @staticmethod
-    def _add_metric(name, documentation, data):
+    def _add_metric(
+        name: str, documentation: str, data: dict
+    ) -> GaugeMetricFamily:
         labels = data.keys()
         values = [data[k] for k in labels]
         g = GaugeMetricFamily(name, documentation, labels=labels)
@@ -39,17 +44,17 @@ class PlatformCollector(object):
         return g
 
     def _info(self):
-        major, minor, patchlevel = self._platform.python_version_tuple()
+        major, minor, patchlevel = platform.python_version_tuple()
         return {
-            "version": self._platform.python_version(),
-            "implementation": self._platform.python_implementation(),
+            "version": platform.python_version(),
+            "implementation": platform.python_implementation(),
             "major": major,
             "minor": minor,
             "patchlevel": patchlevel,
         }
 
     def _java(self):
-        java_version, _, vminfo, osinfo = self._platform.java_ver()
+        java_version, _, vminfo, osinfo = platform.java_ver()
         vm_name, vm_release, vm_vendor = vminfo
         return {
             "jvm_version": java_version,

--- a/asyncworker/metrics/collectors/platform.py
+++ b/asyncworker/metrics/collectors/platform.py
@@ -13,9 +13,6 @@ class PlatformCollector(BaseCollector):
         self, registry: CollectorRegistry, namespace: str = ""
     ) -> None:
         info = self._info()
-        system = platform.system()
-        if system == "Java":
-            info.update(self._java())
 
         if namespace:
             self.namespace = f"{namespace}_"
@@ -51,14 +48,4 @@ class PlatformCollector(BaseCollector):
             "major": major,
             "minor": minor,
             "patchlevel": patchlevel,
-        }
-
-    def _java(self):
-        java_version, _, vminfo, osinfo = platform.java_ver()
-        vm_name, vm_release, vm_vendor = vminfo
-        return {
-            "jvm_version": java_version,
-            "jvm_release": vm_release,
-            "jvm_vendor": vm_vendor,
-            "jvm_name": vm_name,
         }

--- a/asyncworker/metrics/collectors/process.py
+++ b/asyncworker/metrics/collectors/process.py
@@ -1,0 +1,1 @@
+from prometheus_client import ProcessCollector

--- a/asyncworker/metrics/definitions/amqp.py
+++ b/asyncworker/metrics/definitions/amqp.py
@@ -2,33 +2,32 @@ from asyncworker.conf import settings
 from asyncworker.metrics.types import Counter, Histogram, Gauge
 
 active_consumers = Gauge(
-    name="asyncworker_amqp_active_consumers",
-    documentation="Count of active consumers",
+    name="amqp_active_consumers", documentation="Count of active consumers"
 )
 
 processed_messages = Counter(
-    name="asyncworker_amqp_processed_messages",
+    name="amqp_processed_messages",
     documentation="Count of total processed messages",
     labelnames=("queue_name", "action"),
 )
 
 active_connections = Gauge(
-    name="asyncworker_amqp_active_connections",
+    name="amqp_active_connections",
     documentation="Count of active AMQP connections",
 )
 
 filled_buckets = Counter(
-    name="asyncworker_amqp_filled_buckets",
+    name="amqp_filled_buckets",
     documentation="Count of total AMQP filled buckets",
 )
 
 flushed_buckets = Counter(
-    name="asyncworker_amqp_flushed_buckets",
+    name="amqp_flushed_buckets",
     documentation="Count of total AMQP buckets flushed due to ",
 )
 
 bucket_handle_duration = Histogram(
-    name="asyncworker_amqp_bucket_handle",
+    name="amqp_bucket_handle",
     documentation="Duration of message handling",
     buckets=settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS,
 )

--- a/asyncworker/metrics/definitions/http.py
+++ b/asyncworker/metrics/definitions/http.py
@@ -2,7 +2,7 @@ from asyncworker.conf import INFINITY
 from asyncworker.metrics.types import Histogram
 
 request_duration = Histogram(
-    name="asyncworker_http_request_duration",
+    name="http_request_duration",
     documentation="HTTP request duration",
     labelnames=("method", "path", "status"),
     buckets=(0.01, 0.05, 0.1, INFINITY),

--- a/asyncworker/metrics/registry.py
+++ b/asyncworker/metrics/registry.py
@@ -2,12 +2,16 @@ import prometheus_client as prometheus
 from prometheus_client.platform_collector import PlatformCollector
 from prometheus_client.process_collector import ProcessCollector
 
-DEFAULT_METRIC_NAMESAPACE = "asyncworker"
+from asyncworker.conf import settings
+
+NAMESPACE = (
+    f"{settings.METRICS_NAMESPACE}_{settings.METRICS_APPPREFIX}"
+    if settings.METRICS_APPPREFIX
+    else f"{settings.METRICS_NAMESPACE}"
+)
 
 REGISTRY = prometheus.CollectorRegistry(auto_describe=True)
 generate_latest = prometheus.generate_latest
 
 PLATFORM_COLLECTOR = PlatformCollector(registry=REGISTRY)
-PROCESS_COLLECTOR = ProcessCollector(
-    namespace=DEFAULT_METRIC_NAMESAPACE, registry=REGISTRY
-)
+PROCESS_COLLECTOR = ProcessCollector(namespace=NAMESPACE, registry=REGISTRY)

--- a/asyncworker/metrics/registry.py
+++ b/asyncworker/metrics/registry.py
@@ -1,8 +1,9 @@
-import prometheus_client as prometheus
-from prometheus_client.platform_collector import PlatformCollector
-from prometheus_client.process_collector import ProcessCollector
+from prometheus_client import CollectorRegistry
 
 from asyncworker.conf import settings
+from asyncworker.metrics.collectors.gc import GCCollector
+from asyncworker.metrics.collectors.platform import PlatformCollector
+from asyncworker.metrics.collectors.process import ProcessCollector
 
 NAMESPACE = (
     f"{settings.METRICS_NAMESPACE}_{settings.METRICS_APPPREFIX}"
@@ -10,8 +11,9 @@ NAMESPACE = (
     else f"{settings.METRICS_NAMESPACE}"
 )
 
-REGISTRY = prometheus.CollectorRegistry(auto_describe=True)
-generate_latest = prometheus.generate_latest
 
-PLATFORM_COLLECTOR = PlatformCollector(registry=REGISTRY)
+REGISTRY = CollectorRegistry(auto_describe=True)
+
+PLATFORM_COLLECTOR = PlatformCollector(registry=REGISTRY, namespace=NAMESPACE)
 PROCESS_COLLECTOR = ProcessCollector(namespace=NAMESPACE, registry=REGISTRY)
+GC_COLLECTOR = GCCollector(registry=REGISTRY, namespace=NAMESPACE)

--- a/asyncworker/metrics/registry.py
+++ b/asyncworker/metrics/registry.py
@@ -1,4 +1,13 @@
 import prometheus_client as prometheus
+from prometheus_client.platform_collector import PlatformCollector
+from prometheus_client.process_collector import ProcessCollector
+
+DEFAULT_METRIC_NAMESAPACE = "asyncworker"
 
 REGISTRY = prometheus.CollectorRegistry(auto_describe=True)
 generate_latest = prometheus.generate_latest
+
+PLATFORM_COLLECTOR = PlatformCollector(registry=REGISTRY)
+PROCESS_COLLECTOR = ProcessCollector(
+    namespace=DEFAULT_METRIC_NAMESAPACE, registry=REGISTRY
+)

--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -1,16 +1,9 @@
 from abc import ABCMeta
-from functools import partial
 
 import prometheus_client as prometheus
 
 from asyncworker.conf import settings
-from asyncworker.metrics.registry import REGISTRY
-
-NAMESPACE = (
-    f"{settings.METRICS_NAMESPACE}_{settings.METRICS_APPPREFIX}"
-    if settings.METRICS_APPPREFIX
-    else f"{settings.METRICS_NAMESPACE}"
-)
+from asyncworker.metrics.registry import REGISTRY, NAMESPACE
 
 
 class _BaseMetric(metaclass=ABCMeta):

--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -7,8 +7,8 @@ from asyncworker.conf import settings
 from asyncworker.metrics.registry import REGISTRY
 
 NAMESPACE = (
-    f"{settings.METRICS_NAMESPACE}_{settings.APPMETRICS_PREFIX}"
-    if settings.APPMETRICS_PREFIX
+    f"{settings.METRICS_NAMESPACE}_{settings.METRICS_APPPREFIX}"
+    if settings.METRICS_APPPREFIX
     else f"{settings.METRICS_NAMESPACE}"
 )
 

--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -28,7 +28,8 @@ class Histogram(_BaseMetric, prometheus.Histogram):
     def __init__(self, name, documentation, **kwargs) -> None:
         kwargs["namespace"] = NAMESPACE
         kwargs["registry"] = REGISTRY
-        kwargs["buckets"] = settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS
+        if not kwargs.get("buckets"):
+            kwargs["buckets"] = settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS
         super().__init__(name, documentation, **kwargs)
 
 

--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -4,7 +4,7 @@ from functools import partial
 import prometheus_client as prometheus
 
 from asyncworker.conf import settings
-from asyncworker.metrics.registry import REGISTRY, DEFAULT_METRIC_NAMESAPACE
+from asyncworker.metrics.registry import REGISTRY
 
 
 class _BaseMetric(metaclass=ABCMeta):
@@ -13,14 +13,14 @@ class _BaseMetric(metaclass=ABCMeta):
 
 class Counter(_BaseMetric, prometheus.Counter):
     def __init__(self, name, documentation, **kwargs) -> None:
-        kwargs["namespace"] = DEFAULT_METRIC_NAMESAPACE
+        kwargs["namespace"] = settings.METRICS_NAMESPACE
         kwargs["registry"] = REGISTRY
         super().__init__(name, documentation, **kwargs)
 
 
 class Histogram(_BaseMetric, prometheus.Histogram):
     def __init__(self, name, documentation, **kwargs) -> None:
-        kwargs["namespace"] = DEFAULT_METRIC_NAMESAPACE
+        kwargs["namespace"] = settings.METRICS_NAMESPACE
         kwargs["registry"] = REGISTRY
         kwargs["buckets"] = settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS
         super().__init__(name, documentation, **kwargs)
@@ -28,6 +28,6 @@ class Histogram(_BaseMetric, prometheus.Histogram):
 
 class Gauge(_BaseMetric, prometheus.Gauge):
     def __init__(self, name, documentation, **kwargs) -> None:
-        kwargs["namespace"] = DEFAULT_METRIC_NAMESAPACE
+        kwargs["namespace"] = settings.METRICS_NAMESPACE
         kwargs["registry"] = REGISTRY
         super().__init__(name, documentation, **kwargs)

--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -6,19 +6,19 @@ from asyncworker.conf import settings
 from asyncworker.metrics.registry import REGISTRY, NAMESPACE
 
 
-class _BaseMetric(metaclass=ABCMeta):
+class Metric(metaclass=ABCMeta):
     pass
 
 
-class Counter(_BaseMetric, prometheus.Counter):
-    def __init__(self, name, documentation, **kwargs) -> None:
+class Counter(Metric, prometheus.Counter):
+    def __init__(self, name: str, documentation: str, **kwargs) -> None:
         kwargs["namespace"] = NAMESPACE
         kwargs["registry"] = REGISTRY
         super().__init__(name, documentation, **kwargs)
 
 
-class Histogram(_BaseMetric, prometheus.Histogram):
-    def __init__(self, name, documentation, **kwargs) -> None:
+class Histogram(Metric, prometheus.Histogram):
+    def __init__(self, name: str, documentation: str, **kwargs) -> None:
         kwargs["namespace"] = NAMESPACE
         kwargs["registry"] = REGISTRY
         if not kwargs.get("buckets"):
@@ -26,8 +26,8 @@ class Histogram(_BaseMetric, prometheus.Histogram):
         super().__init__(name, documentation, **kwargs)
 
 
-class Gauge(_BaseMetric, prometheus.Gauge):
-    def __init__(self, name, documentation, **kwargs) -> None:
+class Gauge(Metric, prometheus.Gauge):
+    def __init__(self, name: str, documentation: str, **kwargs) -> None:
         kwargs["namespace"] = NAMESPACE
         kwargs["registry"] = REGISTRY
         super().__init__(name, documentation, **kwargs)

--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -6,6 +6,12 @@ import prometheus_client as prometheus
 from asyncworker.conf import settings
 from asyncworker.metrics.registry import REGISTRY
 
+NAMESPACE = (
+    f"{settings.METRICS_NAMESPACE}_{settings.APPMETRICS_PREFIX}"
+    if settings.APPMETRICS_PREFIX
+    else f"{settings.METRICS_NAMESPACE}"
+)
+
 
 class _BaseMetric(metaclass=ABCMeta):
     pass
@@ -13,14 +19,14 @@ class _BaseMetric(metaclass=ABCMeta):
 
 class Counter(_BaseMetric, prometheus.Counter):
     def __init__(self, name, documentation, **kwargs) -> None:
-        kwargs["namespace"] = settings.METRICS_NAMESPACE
+        kwargs["namespace"] = NAMESPACE
         kwargs["registry"] = REGISTRY
         super().__init__(name, documentation, **kwargs)
 
 
 class Histogram(_BaseMetric, prometheus.Histogram):
     def __init__(self, name, documentation, **kwargs) -> None:
-        kwargs["namespace"] = settings.METRICS_NAMESPACE
+        kwargs["namespace"] = NAMESPACE
         kwargs["registry"] = REGISTRY
         kwargs["buckets"] = settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS
         super().__init__(name, documentation, **kwargs)
@@ -28,6 +34,6 @@ class Histogram(_BaseMetric, prometheus.Histogram):
 
 class Gauge(_BaseMetric, prometheus.Gauge):
     def __init__(self, name, documentation, **kwargs) -> None:
-        kwargs["namespace"] = settings.METRICS_NAMESPACE
+        kwargs["namespace"] = NAMESPACE
         kwargs["registry"] = REGISTRY
         super().__init__(name, documentation, **kwargs)

--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -11,25 +11,23 @@ class _BaseMetric(metaclass=ABCMeta):
     pass
 
 
-class _Counter(_BaseMetric, prometheus.Counter):
-    pass
+class Counter(_BaseMetric, prometheus.Counter):
+    def __init__(self, name, documentation, **kwargs) -> None:
+        kwargs["namespace"] = DEFAULT_METRIC_NAMESAPACE
+        kwargs["registry"] = REGISTRY
+        super().__init__(name, documentation, **kwargs)
 
 
-class _Histogram(_BaseMetric, prometheus.Histogram):
-    pass
+class Histogram(_BaseMetric, prometheus.Histogram):
+    def __init__(self, name, documentation, **kwargs) -> None:
+        kwargs["namespace"] = DEFAULT_METRIC_NAMESAPACE
+        kwargs["registry"] = REGISTRY
+        kwargs["buckets"] = settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS
+        super().__init__(name, documentation, **kwargs)
 
 
-class _Gauge(_BaseMetric, prometheus.Gauge):
-    pass
-
-
-Counter = partial(
-    _Counter, registry=REGISTRY, namespace=DEFAULT_METRIC_NAMESAPACE
-)
-Histogram = partial(
-    _Histogram,
-    registry=REGISTRY,
-    buckets=settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS,
-    namespace=DEFAULT_METRIC_NAMESAPACE,
-)
-Gauge = partial(_Gauge, registry=REGISTRY, namespace=DEFAULT_METRIC_NAMESAPACE)
+class Gauge(_BaseMetric, prometheus.Gauge):
+    def __init__(self, name, documentation, **kwargs) -> None:
+        kwargs["namespace"] = DEFAULT_METRIC_NAMESAPACE
+        kwargs["registry"] = REGISTRY
+        super().__init__(name, documentation, **kwargs)

--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -1,21 +1,35 @@
 from abc import ABCMeta
+from functools import partial
 
 import prometheus_client as prometheus
 
 from asyncworker.conf import settings
+from asyncworker.metrics.registry import REGISTRY, DEFAULT_METRIC_NAMESAPACE
 
 
 class _BaseMetric(metaclass=ABCMeta):
     pass
 
 
-class Counter(_BaseMetric, prometheus.Counter):
+class _Counter(_BaseMetric, prometheus.Counter):
     pass
 
 
-class Histogram(_BaseMetric, prometheus.Histogram):
-    DEFAULT_BUCKETS = settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS
-
-
-class Gauge(_BaseMetric, prometheus.Gauge):
+class _Histogram(_BaseMetric, prometheus.Histogram):
     pass
+
+
+class _Gauge(_BaseMetric, prometheus.Gauge):
+    pass
+
+
+Counter = partial(
+    _Counter, registry=REGISTRY, namespace=DEFAULT_METRIC_NAMESAPACE
+)
+Histogram = partial(
+    _Histogram,
+    registry=REGISTRY,
+    buckets=settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS,
+    namespace=DEFAULT_METRIC_NAMESAPACE,
+)
+Gauge = partial(_Gauge, registry=REGISTRY, namespace=DEFAULT_METRIC_NAMESAPACE)

--- a/examples/metrics.py
+++ b/examples/metrics.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from aiohttp import web
+
+from asyncworker import App, RouteTypes
+from asyncworker.http.decorators import parse_path
+from asyncworker.http.wrapper import RequestWrapper
+from asyncworker.metrics import Counter, Gauge
+
+app = App()
+
+
+c = Counter("count", "Contagem")
+g = Gauge("duration", "Duration")
+
+g_label = Gauge("with_label", "Gauge with label", labelnames=["label"])
+
+
+@app.route(["/count"], type=RouteTypes.HTTP, methods=["GET"])
+async def handler():
+    c.inc()
+    return web.json_response({})
+
+
+@app.route(["/sleep/{duration}"], type=RouteTypes.HTTP, methods=["GET"])
+@parse_path
+async def by_id(duration: int):
+    with g.time():
+        await asyncio.sleep(duration)
+    return web.json_response({})
+
+
+@app.route(["/gauge-with-label/{label}"], type=RouteTypes.HTTP, methods=["GET"])
+@parse_path
+async def one_param(label: str):
+    with g_label.labels(label=label).track_inprogress():
+        pass
+    return web.json_response({})
+
+
+app.run()

--- a/tests/http/test_metrics_endpoint.py
+++ b/tests/http/test_metrics_endpoint.py
@@ -1,0 +1,130 @@
+from functools import partial
+from http import HTTPStatus
+
+from aiohttp import web
+from asynctest import TestCase
+from prometheus_client.parser import text_string_to_metric_families
+
+from asyncworker import App, RouteTypes
+from asyncworker.conf import settings
+from asyncworker.http.decorators import parse_path
+from asyncworker.metrics import Counter, Gauge, Histogram
+from asyncworker.metrics.aiohttp_resources import metrics_route_handler
+from asyncworker.metrics.registry import REGISTRY, DEFAULT_METRIC_NAMESAPACE
+from asyncworker.testing import HttpClientContext
+
+
+class MetricsEndpointTest(TestCase):
+    use_default_loop = True
+    maxDiff = None
+
+    async def setUp(self):
+        self.app = App()
+        self.app.route(["/metrics"], type=RouteTypes.HTTP, methods=["GET"])(
+            metrics_route_handler
+        )
+
+    async def test_count_metric(self):
+        metric_name = "myapp_example_counter"
+        counter = Counter(metric_name, "Um contador simples", registry=REGISTRY)
+
+        @self.app.route(["/foo"], type=RouteTypes.HTTP, methods=["GET"])
+        async def _handler():
+            counter.inc()
+            return web.json_response({})
+
+        async with HttpClientContext(self.app) as client:
+            await client.get("/foo")
+            await client.get("/foo")
+
+            metrics = await client.get("/metrics")
+            self.assertEqual(HTTPStatus.OK, metrics.status)
+
+            data = await metrics.text()
+            metrics_parsed = list(text_string_to_metric_families(data))
+            count_metric = [
+                m
+                for m in metrics_parsed
+                if m.name == f"{DEFAULT_METRIC_NAMESAPACE}_{metric_name}"
+            ]
+            self.assertEqual(1, len(count_metric))
+            self.assertEqual(2.0, count_metric[0].samples[0].value)
+
+    async def test_gauge_metric(self):
+        metric_name = "myapp_example_gauge"
+        gauge = Gauge(metric_name, "um Gauge simples", registry=REGISTRY)
+
+        @self.app.route(["/foo/{value}"], type=RouteTypes.HTTP, methods=["GET"])
+        @parse_path
+        async def _handler(value: int):
+            gauge.inc(value)
+            return web.json_response({})
+
+        async with HttpClientContext(self.app) as client:
+            await client.get("/foo/10")
+            await client.get("/foo/20")
+            await client.get("/foo/-5")
+
+            metrics = await client.get("/metrics")
+            self.assertEqual(HTTPStatus.OK, metrics.status)
+
+            data = await metrics.text()
+            metrics_parsed = list(text_string_to_metric_families(data))
+            gauge_metric = [
+                m
+                for m in metrics_parsed
+                if m.name == f"{DEFAULT_METRIC_NAMESAPACE}_{metric_name}"
+            ]
+            self.assertEqual(1, len(gauge_metric))
+            self.assertEqual(25.0, gauge_metric[0].samples[0].value)
+
+    async def test_histogram_metric(self):
+        metric_name = "myapp_example_histogram"
+        histogram = Histogram(
+            metric_name, "um Histogram simples", registry=REGISTRY
+        )
+
+        @self.app.route(["/foo/{value}"], type=RouteTypes.HTTP, methods=["GET"])
+        @parse_path
+        async def _handler(value: int):
+            histogram.observe(value)
+            return web.json_response({})
+
+        async with HttpClientContext(self.app) as client:
+            await client.get("/foo/8")
+            await client.get("/foo/20")
+            await client.get("/foo/12")
+            await client.get("/foo/201")
+
+            metrics = await client.get("/metrics")
+            self.assertEqual(HTTPStatus.OK, metrics.status)
+
+            data = await metrics.text()
+            metrics_parsed = list(text_string_to_metric_families(data))
+            histogram_metric = [
+                m
+                for m in metrics_parsed
+                if m.name == f"{DEFAULT_METRIC_NAMESAPACE}_{metric_name}"
+            ]
+            self.assertEqual(1, len(histogram_metric))
+            self._assert_bucket_value(
+                1.0,
+                settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS[0],
+                histogram_metric[0].samples[0],
+            )
+            self._assert_bucket_value(
+                3.0,
+                settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS[1],
+                histogram_metric[0].samples[1],
+            )
+            self._assert_bucket_value(
+                3.0,
+                settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS[3],
+                histogram_metric[0].samples[3],
+            )
+
+    def _assert_bucket_value(self, expected_value, bucket_value, metric):
+        self.assertEqual(
+            {"value": expected_value, "le": str(float(bucket_value))},
+            {"value": metric.value, **metric.labels},
+        )

--- a/tests/http/test_metrics_endpoint.py
+++ b/tests/http/test_metrics_endpoint.py
@@ -63,10 +63,10 @@ class MetricsEndpointTest(TestCase):
         from asyncworker.metrics import types
         from asyncworker import conf
 
-        with mock.patch.dict(os.environ, ASYNCWORKER_APPMETRICS_PREFIX="myapp"):
+        with mock.patch.dict(os.environ, ASYNCWORKER_METRICS_APPPREFIX="myapp"):
             reload(conf)
             reload(types)
-            self.assertEqual("myapp", conf.settings.APPMETRICS_PREFIX)
+            self.assertEqual("myapp", conf.settings.METRICS_APPPREFIX)
             c = types.Counter("my_other_counter", "Docs")
             result = c.collect()[0]
             self.assertEqual("asyncworker_myapp_my_other_counter", result.name)

--- a/tests/http/test_metrics_endpoint.py
+++ b/tests/http/test_metrics_endpoint.py
@@ -51,6 +51,27 @@ class MetricsEndpointTest(TestCase):
             "histogram_with_ns",
         )
 
+    async def test_histogram_override_buckets(self):
+        h = Histogram(
+            "my_new_histogram", "New Histogram", buckets=[7.0, 12.0, 30.0]
+        )
+        h.observe(5)
+        h.observe(9)
+
+        samples = h.collect()[0].samples
+        self.assertEqual(
+            {"value": 1.0, "le": "7.0"},
+            {"value": samples[0].value, **samples[0].labels},
+        )
+        self.assertEqual(
+            {"value": 2.0, "le": "12.0"},
+            {"value": samples[1].value, **samples[1].labels},
+        )
+        self.assertEqual(
+            {"value": 2.0, "le": "30.0"},
+            {"value": samples[2].value, **samples[2].labels},
+        )
+
     async def test_metric_cant_override_registry(self):
         registry = CollectorRegistry()
         Counter("counter", "Doc", registry=registry)

--- a/tests/metrics/test_gc_collector.py
+++ b/tests/metrics/test_gc_collector.py
@@ -1,0 +1,57 @@
+import os
+from importlib import reload
+
+from asynctest import TestCase, mock
+
+
+class GCCollectorest(TestCase):
+    async def test_use_global_namespace(self):
+        from asyncworker import conf
+        from asyncworker.metrics import registry
+
+        with mock.patch.dict(os.environ, ASYNCWORKER_METRICS_APPPREFIX="myapp"):
+            reload(conf)
+            reload(registry)
+            pc = registry.GC_COLLECTOR
+
+            metrics = pc.collect()
+            self.assertEqual(3, len(pc.collect()))
+
+            metric_names = [m.name for m in metrics]
+            expexted_metric_names = [
+                "asyncworker_myapp_python_gc_objects_collected",
+                "asyncworker_myapp_python_gc_objects_uncollectable",
+                "asyncworker_myapp_python_gc_collections",
+            ]
+            self.assertEqual(expexted_metric_names, metric_names)
+
+            expected_samples_names_collected = [
+                "asyncworker_myapp_python_gc_objects_collected_total",
+                "asyncworker_myapp_python_gc_objects_collected_total",
+                "asyncworker_myapp_python_gc_objects_collected_total",
+            ]
+            samples_names_collected = [s.name for s in metrics[0].samples]
+            self.assertEquals(
+                expected_samples_names_collected, samples_names_collected
+            )
+
+            expected_samples_names_uncollectable = [
+                "asyncworker_myapp_python_gc_objects_uncollectable_total",
+                "asyncworker_myapp_python_gc_objects_uncollectable_total",
+                "asyncworker_myapp_python_gc_objects_uncollectable_total",
+            ]
+            samples_names_uncollectable = [s.name for s in metrics[1].samples]
+            self.assertEquals(
+                expected_samples_names_uncollectable,
+                samples_names_uncollectable,
+            )
+
+            expected_samples_names_collections = [
+                "asyncworker_myapp_python_gc_collections_total",
+                "asyncworker_myapp_python_gc_collections_total",
+                "asyncworker_myapp_python_gc_collections_total",
+            ]
+            samples_names_collections = [s.name for s in metrics[2].samples]
+            self.assertEquals(
+                expected_samples_names_collections, samples_names_collections
+            )

--- a/tests/metrics/test_platform_collector.py
+++ b/tests/metrics/test_platform_collector.py
@@ -1,0 +1,22 @@
+import os
+from importlib import reload
+
+from asynctest import TestCase, mock
+
+
+class PlatformCollectorest(TestCase):
+    async def test_use_global_namespace(self):
+        from asyncworker import conf
+        from asyncworker.metrics import registry
+
+        with mock.patch.dict(os.environ, ASYNCWORKER_METRICS_APPPREFIX="myapp"):
+            reload(conf)
+            reload(registry)
+            pc = registry.PLATFORM_COLLECTOR
+
+            metrics = pc.collect()
+            self.assertEqual(1, len(pc.collect()))
+
+            metric_names = [m.name for m in metrics]
+            expected_metric_names = ["asyncworker_myapp_python_info"]
+            self.assertEqual(expected_metric_names, metric_names)

--- a/tests/metrics/test_process_collector.py
+++ b/tests/metrics/test_process_collector.py
@@ -1,0 +1,31 @@
+import os
+from importlib import reload
+
+from asynctest import TestCase, mock
+
+from asyncworker.metrics.registry import PROCESS_COLLECTOR
+
+
+class ProcessCollectorTest(TestCase):
+    async def test_use_global_namespace(self):
+        from asyncworker import conf
+        from asyncworker.metrics import registry
+
+        with mock.patch.dict(os.environ, ASYNCWORKER_METRICS_APPPREFIX="myapp"):
+            reload(conf)
+            reload(registry)
+            pc = registry.PROCESS_COLLECTOR
+
+            metrics = pc.collect()
+            self.assertEqual(6, len(pc.collect()))
+
+            metric_names = [m.name for m in metrics]
+            expexted_metric_names = [
+                "asyncworker_myapp_process_virtual_memory_bytes",
+                "asyncworker_myapp_process_resident_memory_bytes",
+                "asyncworker_myapp_process_start_time_seconds",
+                "asyncworker_myapp_process_cpu_seconds",
+                "asyncworker_myapp_process_open_fds",
+                "asyncworker_myapp_process_max_fds",
+            ]
+            self.assertEqual(expexted_metric_names, metric_names)

--- a/tests/metrics/test_process_collector.py
+++ b/tests/metrics/test_process_collector.py
@@ -3,8 +3,6 @@ from importlib import reload
 
 from asynctest import TestCase, mock
 
-from asyncworker.metrics.registry import PROCESS_COLLECTOR
-
 
 class ProcessCollectorTest(TestCase):
     async def test_use_global_namespace(self):


### PR DESCRIPTION
Agora todas as métricas importadas de `asyncworker.metrics.types.*` e
também de `asyncoworker.metrics.*` estão vinculadas ao nosso registry
interno.

Adicionado também um namespace padrão.

## Dúvidas

- ~Preciamos de um novo prefixo que pode escolhido pelo usuário e que será colocado no nome das métricas **internas** expostas por padrão pelo asyncworker?~ Penso que sim. É um prefixo apenas para que as métricas fiquem únicas **por app**. Uma sugestão de nome: `ASYNCWORKER_APPMETRICS_PREFIX`. O valor padrão é vazio. https://github.com/b2wdigital/async-worker/pull/203#issuecomment-629842314
- ~Essa opção seria obrigatória?~ Opcional
- [x] Como o `mypy` se comporta com a questão do `partial()`? https://github.com/b2wdigital/async-worker/pull/203#issuecomment-629729987 Usaremos `__init__()` e `super()`.
- [x] Adicionar possibilidade de mudar o prefix de aplicação com uma env: `ASYNCWORKER_APPMETRICS_PREFIX`
- [x] Mudar o nome da env para `ASYNCWORKER_METRICS_APPPREFIX`. Ajustar os testes.
- [x] Permitir que o `Histogram` possa fazer override do parametro `buckets`
- [x] Ajustar o `asyncworker.metrics.registry.ProcessCollector()` para usar esse novo prefixo (namespace + app_prefix). Talvez mover a lógica do cálculo do namespace final para junto do registry.
- [x] Fazer o PlatformCollector obedecer o namespace
- [x] Adicionar o GCCollector ao Registry
- [x] Fazer o GCCollector obedecer o namespace

Como o prefixo padrão também foi movido para o settings acaba sendo possível mudá-lo com a env `ASYNCWORKER_METRICS_NAMESPACE`. Cabe a nós documentar esse detalhe, ou não. =D