### PR TITLE
Documentando como atualizar um projeto asyncworker

### DIFF
--- a/asyncworker/metrics/types.py
+++ b/asyncworker/metrics/types.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta
-from functools import partial
 
 import prometheus_client as prometheus
 

--- a/docs-src/changelog/v0.15.0.rst
+++ b/docs-src/changelog/v0.15.0.rst
@@ -1,0 +1,51 @@
+0.15.0
+================
+
+
+Data de release:
+
+Tag: `0.15.0 <https://github.com/b2wdigital/async-worker/releases/tag/0.15.0>`_
+
+ * `PR #201 <https://github.com/b2wdigital/async-worker/pull/201>`_ prometheus integration
+
+Raw Commits: `0.14.0 <https://github.com/b2wdigital/async-worker/compare/0.14.1...0.15.0>`_
+
+
+Notas de atualização
+--------------------
+
+A partir dessa versão é possível exportar métricas no formato do  `Prometheus <https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format>`_. Mais detalhes na documentação sobre :ref:`Métricas <handler-metrics>`.
+
+
+Isso significa que o asyncworker pode adicionar uma rota HTTP com path ``/metrics`` (valor padão da config :py:class:`settings.METRICS_HTTP_ROUTE_PATH <asyncworker.conf.Settings>`.
+Essa configuração está ligada por paadrão e pode ser desligada com a ENV VAR ``ASYNCWORKER_METRICS_ENABLE=0``. Mais detalhes na documentação sobre :ref:`Configuração de métricas <metrics-config>`.
+
+Se a usa aplicação já exporta métricas e faz isso usando as classes do ``prometheus_client`` o ideal é que você ajuste seu código para que faça uso das classes expostas pelo asyncworker (``asyncworker.metrics.*``). Se seu código importa as métricas dessa forma:
+
+.. code:: python
+
+  from prometheus_client import Counter, Gauge, Histogram
+
+deve mudar para:
+
+.. code:: python
+
+ from asyncworker.metrics import Counter, Gauge, Histogram
+
+
+As classes de métricas do asyncworker podem ser usadas como `drop-in replacement` para as classes expostas pelo ``prometheus_client``.
+
+
+Se você faz uso de classes que ainda não são expostas pelo asyncworker, como por exemplo ``Enum, Summary, Info`` deve fazer a instanciação delas dessa forma:
+
+.. code:: python
+
+  from asyncworker.metrics.registry import REGISTRY
+  from prometheus_client import Summary
+
+  _s = Summary(..., registry=REGISTRY)
+
+
+Dessa forma suas métricas estarão vinculadas ao MetricsRegistry do asyncworker e serão expostas no response do ``/metrics``.
+
+Algumas métricas já são automaticamente expostas pelo asyncworker. Elas estão documentadas aqui: :ref:`Métricas expostas automaticamente <asyncworker-auto-metrics>`.

--- a/docs-src/userguide/metrics/autoexposed-metrics.rst
+++ b/docs-src/userguide/metrics/autoexposed-metrics.rst
@@ -1,7 +1,8 @@
+.. _asyncworker-auto-metrics:
+
 Métricas expostas automaticamente
 ===================================
 
-.. _asyncworker-auto-metrics:
 
 O asyncworker já expõe automaticamente algumas métricas. Porém algumas métricas são independentes do tipo de handler e elas estão documentadas aqui.
 


### PR DESCRIPTION
Mostra como atualizar para a versão onde temos a possibilidade de
expor métricas no formato do Prometheus