### PR TITLE
Corrigindo exemplo do rabbitmq

### DIFF
--- a/examples/rabbitmq.py
+++ b/examples/rabbitmq.py
@@ -6,10 +6,7 @@ from asyncworker.options import RouteTypes, Options
 from asyncworker.rabbitmq import RabbitMQMessage
 
 amqp_conn = AMQPConnection(
-    hostname="127.0.0.1",
-    username="guest",
-    password="guest",
-    prefetch_count=1024,
+    hostname="127.0.0.1", username="guest", password="guest", prefetch=1024
 )
 
 app = App(connections=[amqp_conn])


### PR DESCRIPTION
Estava usando o parametro errado para o prefech.

O model de AMQPConnection espera `prefetch` e estávamos passando
`prefetch_count`.

Mas o model está configurado para ignorar atributos
adicionais (Comportamento padrão do pydantic). Levei um debugando até perceber que o problema era esse.

Talvez faça sentido termos modelos mais estritos, assim esse tipo de
problema não seria nem possível de acontecer.