### PR TITLE
Raise TypeError se um handler não for async

### DIFF
--- a/asyncworker/app.py
+++ b/asyncworker/app.py
@@ -127,6 +127,10 @@ class App(MutableMapping, Freezable):
             if not asyncio.iscoroutinefunction(handler):
                 try:
                     handler = f.__call__
+                    if not asyncio.iscoroutinefunction(handler):
+                        raise TypeError(
+                            f"handler must be a coroutine: {handler}"
+                        )
                 except AttributeError:
                     raise TypeError(
                         f"Object passed as handler is not callable: {f}"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -194,3 +194,19 @@ class AMQPRouteTests(TestCase):
             resp = await client.get("/?a=30&b=42")
             data = await resp.json()
             self.assertEqual({"a": "30", "b": "42"}, data)
+
+    async def test_raises_if_handler_is_not_coroutine(self):
+        """
+        Certifica que um decorator customizado pode receber 
+        uma instânccia de aiohttp.web.Request
+        """
+        app = App()
+
+        def handler(wrapper: RequestWrapper):
+            req = wrapper.http_request
+            return web.json_response(dict(req.query.items()))
+
+        with self.assertRaises(TypeError) as ex:
+            app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])(handler)
+
+        self.assertTrue("handler must be a coroutine" in ex.exception.args[0])


### PR DESCRIPTION
Atualmente permitimos que um handler síncrono seja registrado e o erro
só vai acontecer em runtime. Nesse commit validamos isso para que o erro
aconteca o mais cedo possível.