### PR TITLE
Depreciando @app.route() e criando decorators específicos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
   py36: &template
     docker:
       - image: circleci/python:3.6
-      - image: rabbitmq:3.7-alpine
+      - image: rabbitmq:3.7-management-alpine
     steps:
       - checkout
       - run:
@@ -65,13 +65,13 @@ jobs:
     <<: *template
     docker:
       - image: circleci/python:3.7
-      - image: rabbitmq:3.7-alpine
+      - image: rabbitmq:3.7-management-alpine
 
   py38:
     <<: *template
     docker:
       - image: circleci/python:3.8
-      - image: rabbitmq:3.7-alpine
+      - image: rabbitmq:3.7-management-alpine
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Abaixo estão alguns exemplos bem simples que dão uma ideia do projeto e de com
 ```python
 from aiohttp import web
 
-from asyncworker import App, RouteTypes
+from asyncworker import App
 
 app = App()
 
 
-@app.route(["/", "/other"], type=RouteTypes.HTTP, methods=["GET"])
+@app.http.get(["/", "/other"])
 async def handler():
     return web.json_response({})
 
@@ -49,8 +49,8 @@ from typing import List
 
 from asyncworker import App
 from asyncworker.connections import AMQPConnection
-from asyncworker.options import RouteTypes, Options
-from asyncworker.rabbitmq import RabbitMQMessage
+from asyncworker.options import Options
+from asyncworker.rabbitmq import RabbitMQMessage, AMQPRouteOptions
 
 amqp_conn = AMQPConnection(
     hostname="127.0.0.1",
@@ -62,8 +62,8 @@ amqp_conn = AMQPConnection(
 app = App(connections=[amqp_conn])
 
 
-@app.route(
-    ["queue", "queue-2"], type=RouteTypes.AMQP_RABBITMQ, options={Options.BULK_SIZE: 512}
+@app.amqp.consume(
+    ["queue", "queue-2"], options=AMQPRouteOptions(bulk_size=512)
 )
 async def handler(messages: List[RabbitMQMessage]):
     print(f"Received {len(messages)} messages")

--- a/asyncworker/app.py
+++ b/asyncworker/app.py
@@ -5,9 +5,10 @@ from typing import Iterable, Callable, Coroutine, Dict, Any, Optional
 
 from asyncworker.conf import logger
 from asyncworker.connections import ConnectionsMapping, Connection
-from asyncworker.entrypoints import HTTPEntryPointImpl, AMQPRouteEntryPointImpl
+from asyncworker.entrypoints import HTTPEntryPointImpl
 from asyncworker.exceptions import InvalidRoute, InvalidConnection
 from asyncworker.options import RouteTypes, Options, DefaultValues
+from asyncworker.rabbitmq.entrypoints import AMQPRouteEntryPointImpl
 from asyncworker.routes import RoutesRegistry, Route
 from asyncworker.signals.base import Signal, Freezable
 from asyncworker.signals.handlers.http import HTTPServer

--- a/asyncworker/app.py
+++ b/asyncworker/app.py
@@ -110,11 +110,11 @@ class App(MutableMapping, Freezable):
         return asyncio.ensure_future(self._on_shutdown.send(self))
 
     @property
-    def http(self):
+    def http(self) -> HTTPEntryPointImpl:
         return HTTPEntryPointImpl(self)
 
     @property
-    def amqp(self):
+    def amqp(self) -> AMQPRouteEntryPointImpl:
         return AMQPRouteEntryPointImpl(self)
 
     def route(

--- a/asyncworker/app.py
+++ b/asyncworker/app.py
@@ -1,29 +1,14 @@
 import asyncio
-import typing
-from abc import ABC, abstractmethod
 from collections import MutableMapping
 from signal import Signals
-from typing import (
-    Iterable,
-    Callable,
-    Coroutine,
-    Dict,
-    Any,
-    Optional,
-    List,
-    Generic,
-    TypeVar,
-)
+from typing import Iterable, Callable, Coroutine, Dict, Any, Optional
 
-from asyncworker.app_entrypoints import (
-    HTTPEntryPointImpl,
-    AMQPRouteEntryPointImpl,
-)
 from asyncworker.conf import logger
 from asyncworker.connections import ConnectionsMapping, Connection
+from asyncworker.entrypoints import HTTPEntryPointImpl, AMQPRouteEntryPointImpl
 from asyncworker.exceptions import InvalidRoute, InvalidConnection
 from asyncworker.options import RouteTypes, Options, DefaultValues
-from asyncworker.routes import RoutesRegistry, Route, RouteHandler
+from asyncworker.routes import RoutesRegistry, Route
 from asyncworker.signals.base import Signal, Freezable
 from asyncworker.signals.handlers.http import HTTPServer
 from asyncworker.signals.handlers.rabbitmq import RabbitMQ

--- a/asyncworker/app.py
+++ b/asyncworker/app.py
@@ -1,14 +1,29 @@
 import asyncio
-import builtins
+import typing
+from abc import ABC, abstractmethod
 from collections import MutableMapping
 from signal import Signals
-from typing import Iterable, Callable, Coroutine, Dict, Any, Optional
+from typing import (
+    Iterable,
+    Callable,
+    Coroutine,
+    Dict,
+    Any,
+    Optional,
+    List,
+    Generic,
+    TypeVar,
+)
 
+from asyncworker.app_entrypoints import (
+    HTTPEntryPointImpl,
+    AMQPRouteEntryPointImpl,
+)
 from asyncworker.conf import logger
 from asyncworker.connections import ConnectionsMapping, Connection
 from asyncworker.exceptions import InvalidRoute, InvalidConnection
 from asyncworker.options import RouteTypes, Options, DefaultValues
-from asyncworker.routes import RoutesRegistry, Route
+from asyncworker.routes import RoutesRegistry, Route, RouteHandler
 from asyncworker.signals.base import Signal, Freezable
 from asyncworker.signals.handlers.http import HTTPServer
 from asyncworker.signals.handlers.rabbitmq import RabbitMQ
@@ -107,6 +122,14 @@ class App(MutableMapping, Freezable):
         a SIGINT or SIGTERM
         """
         return asyncio.ensure_future(self._on_shutdown.send(self))
+
+    @property
+    def http(self):
+        return HTTPEntryPointImpl(self)
+
+    @property
+    def amqp(self):
+        return AMQPRouteEntryPointImpl(self)
 
     def route(
         self,

--- a/asyncworker/app.py
+++ b/asyncworker/app.py
@@ -199,7 +199,10 @@ class App(MutableMapping, Freezable):
         return wrapper
 
     def get_connection_for_route(self, route_info: Route):
-        route_connection = route_info.options.get("connection")
+        route_connection = route_info.connection
+        if route_connection is None:
+            route_connection = route_info.options.get("connection")
+
         connections = self.connections.with_type(route_info.type)
         if route_connection is not None:
             if isinstance(route_connection, Connection):

--- a/asyncworker/app.py
+++ b/asyncworker/app.py
@@ -5,8 +5,8 @@ from typing import Iterable, Callable, Coroutine, Dict, Any, Optional
 
 from asyncworker.conf import logger
 from asyncworker.connections import ConnectionsMapping, Connection
-from asyncworker.entrypoints import HTTPEntryPointImpl
 from asyncworker.exceptions import InvalidRoute, InvalidConnection
+from asyncworker.http.entrypoints import HTTPEntryPointImpl
 from asyncworker.options import RouteTypes, Options, DefaultValues
 from asyncworker.rabbitmq.entrypoints import AMQPRouteEntryPointImpl
 from asyncworker.routes import RoutesRegistry, Route

--- a/asyncworker/app_entrypoints.py
+++ b/asyncworker/app_entrypoints.py
@@ -1,0 +1,81 @@
+from abc import ABC
+from asyncio import iscoroutinefunction
+from typing import Generic, TypeVar, List, Optional
+
+import asyncworker
+from asyncworker.routes import (
+    RoutesRegistry,
+    HTTPRoute,
+    RouteHandler,
+    AMQPRoute,
+    _AMQPRouteOptions,
+)
+
+T = TypeVar("T")
+
+
+def _extract_async_callable(handler) -> RouteHandler:
+
+    cb = handler
+
+    if not iscoroutinefunction(cb):
+        try:
+            cb = handler.__call__
+            if not iscoroutinefunction(cb):
+                raise TypeError(f"handler must be async: {cb}")
+        except AttributeError as e:
+            raise TypeError(f"Object passed as handler is not callable: {cb}")
+
+    return cb
+
+
+def _register_http_handler(
+    registry: RoutesRegistry, routes: List[str], method: str
+):
+    def _wrap(f):
+
+        cb = _extract_async_callable(f)
+        route = HTTPRoute(handler=cb, routes=routes, methods=[method])
+        registry.add_http_route(route)
+
+        return f
+
+    return _wrap
+
+
+def _register_amqp_handler(
+    registry: RoutesRegistry,
+    routes: List[str],
+    options: Optional[_AMQPRouteOptions],
+):
+    def _wrap(f):
+
+        cb = _extract_async_callable(f)
+        route = AMQPRoute(handler=cb, routes=routes, options=options)
+        registry.add_amqp_route(route)
+
+        return f
+
+    return _wrap
+
+
+class EntrypointInterface(ABC, Generic[T]):
+    def __init__(self, app: "asyncworker.App") -> None:
+        self.app = app
+
+
+class HTTPEntryPointImpl(EntrypointInterface):
+    def route(self, routes: List[str], method: str):
+        return _register_http_handler(self.app.routes_registry, routes, method)
+
+    def get(self, routes: List[str]):
+        return self.route(routes=routes, method="GET")
+
+
+class AMQPRouteEntryPointImpl(EntrypointInterface):
+    def consume(
+        self,
+        routes: List[str],
+        options: Optional[_AMQPRouteOptions] = _AMQPRouteOptions(),
+    ):
+        return _register_amqp_handler(self.app.routes_registry, routes, options)

--- a/asyncworker/entrypoints.py
+++ b/asyncworker/entrypoints.py
@@ -71,6 +71,21 @@ class HTTPEntryPointImpl(EntrypointInterface):
     def get(self, routes: List[str]):
         return self.route(routes=routes, method="GET")
 
+    def head(self, routes: List[str]):
+        return self.route(routes=routes, method="HEAD")
+
+    def delete(self, routes: List[str]):
+        return self.route(routes=routes, method="DELETE")
+
+    def patch(self, routes: List[str]):
+        return self.route(routes=routes, method="PATCH")
+
+    def post(self, routes: List[str]):
+        return self.route(routes=routes, method="POST")
+
+    def put(self, routes: List[str]):
+        return self.route(routes=routes, method="PUT")
+
 
 class AMQPRouteEntryPointImpl(EntrypointInterface):
     def consume(

--- a/asyncworker/entrypoints.py
+++ b/asyncworker/entrypoints.py
@@ -1,10 +1,9 @@
 from abc import ABC
 from asyncio import iscoroutinefunction
-from typing import Generic, TypeVar, List
+from typing import Generic, TypeVar
 
 import asyncworker
-from asyncworker.http import HTTPMethods
-from asyncworker.routes import RoutesRegistry, HTTPRoute, RouteHandler
+from asyncworker.routes import RouteHandler
 
 T = TypeVar("T")
 
@@ -24,43 +23,6 @@ def _extract_async_callable(handler) -> RouteHandler:
     return cb
 
 
-def _register_http_handler(
-    registry: RoutesRegistry, routes: List[str], method: str
-):
-    def _wrap(f):
-
-        cb = _extract_async_callable(f)
-        route = HTTPRoute(handler=cb, routes=routes, methods=[method])
-        registry.add_http_route(route)
-
-        return f
-
-    return _wrap
-
-
 class EntrypointInterface(ABC, Generic[T]):
     def __init__(self, app: "asyncworker.App") -> None:
         self.app = app
-
-
-class HTTPEntryPointImpl(EntrypointInterface):
-    def route(self, routes: List[str], method: str):
-        return _register_http_handler(self.app.routes_registry, routes, method)
-
-    def get(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.GET)
-
-    def head(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.HEAD)
-
-    def delete(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.DELETE)
-
-    def patch(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.PATCH)
-
-    def post(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.POST)
-
-    def put(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.PUT)

--- a/asyncworker/entrypoints.py
+++ b/asyncworker/entrypoints.py
@@ -3,6 +3,7 @@ from asyncio import iscoroutinefunction
 from typing import Generic, TypeVar, List, Optional
 
 import asyncworker
+from asyncworker.http import HTTPMethods
 from asyncworker.routes import (
     RoutesRegistry,
     HTTPRoute,
@@ -69,22 +70,22 @@ class HTTPEntryPointImpl(EntrypointInterface):
         return _register_http_handler(self.app.routes_registry, routes, method)
 
     def get(self, routes: List[str]):
-        return self.route(routes=routes, method="GET")
+        return self.route(routes=routes, method=HTTPMethods.GET)
 
     def head(self, routes: List[str]):
-        return self.route(routes=routes, method="HEAD")
+        return self.route(routes=routes, method=HTTPMethods.HEAD)
 
     def delete(self, routes: List[str]):
-        return self.route(routes=routes, method="DELETE")
+        return self.route(routes=routes, method=HTTPMethods.DELETE)
 
     def patch(self, routes: List[str]):
-        return self.route(routes=routes, method="PATCH")
+        return self.route(routes=routes, method=HTTPMethods.PATCH)
 
     def post(self, routes: List[str]):
-        return self.route(routes=routes, method="POST")
+        return self.route(routes=routes, method=HTTPMethods.POST)
 
     def put(self, routes: List[str]):
-        return self.route(routes=routes, method="PUT")
+        return self.route(routes=routes, method=HTTPMethods.PUT)
 
 
 class AMQPRouteEntryPointImpl(EntrypointInterface):

--- a/asyncworker/http/__init__.py
+++ b/asyncworker/http/__init__.py
@@ -1,1 +1,2 @@
+from asyncworker.http.methods import HTTPMethods
 from asyncworker.http.wrapper import RequestWrapper

--- a/asyncworker/http/entrypoints.py
+++ b/asyncworker/http/entrypoints.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, List
 
 from asyncworker.entrypoints import _extract_async_callable, EntrypointInterface
 from asyncworker.http import HTTPMethods
@@ -6,8 +6,8 @@ from asyncworker.routes import RoutesRegistry, HTTPRoute
 
 
 def _register_http_handler(
-    registry: RoutesRegistry, routes: List[str], method: str
-):
+    registry: RoutesRegistry, routes: List[str], method: HTTPMethods
+) -> Callable:
     def _wrap(f):
 
         cb = _extract_async_callable(f)
@@ -20,23 +20,23 @@ def _register_http_handler(
 
 
 class HTTPEntryPointImpl(EntrypointInterface):
-    def route(self, routes: List[str], method: str):
+    def _route(self, routes: List[str], method: HTTPMethods) -> Callable:
         return _register_http_handler(self.app.routes_registry, routes, method)
 
-    def get(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.GET)
+    def get(self, routes: List[str]) -> Callable:
+        return self._route(routes=routes, method=HTTPMethods.GET)
 
-    def head(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.HEAD)
+    def head(self, routes: List[str]) -> Callable:
+        return self._route(routes=routes, method=HTTPMethods.HEAD)
 
-    def delete(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.DELETE)
+    def delete(self, routes: List[str]) -> Callable:
+        return self._route(routes=routes, method=HTTPMethods.DELETE)
 
-    def patch(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.PATCH)
+    def patch(self, routes: List[str]) -> Callable:
+        return self._route(routes=routes, method=HTTPMethods.PATCH)
 
-    def post(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.POST)
+    def post(self, routes: List[str]) -> Callable:
+        return self._route(routes=routes, method=HTTPMethods.POST)
 
-    def put(self, routes: List[str]):
-        return self.route(routes=routes, method=HTTPMethods.PUT)
+    def put(self, routes: List[str]) -> Callable:
+        return self._route(routes=routes, method=HTTPMethods.PUT)

--- a/asyncworker/http/entrypoints.py
+++ b/asyncworker/http/entrypoints.py
@@ -1,0 +1,42 @@
+from typing import List
+
+from asyncworker.entrypoints import _extract_async_callable, EntrypointInterface
+from asyncworker.http import HTTPMethods
+from asyncworker.routes import RoutesRegistry, HTTPRoute
+
+
+def _register_http_handler(
+    registry: RoutesRegistry, routes: List[str], method: str
+):
+    def _wrap(f):
+
+        cb = _extract_async_callable(f)
+        route = HTTPRoute(handler=cb, routes=routes, methods=[method])
+        registry.add_http_route(route)
+
+        return f
+
+    return _wrap
+
+
+class HTTPEntryPointImpl(EntrypointInterface):
+    def route(self, routes: List[str], method: str):
+        return _register_http_handler(self.app.routes_registry, routes, method)
+
+    def get(self, routes: List[str]):
+        return self.route(routes=routes, method=HTTPMethods.GET)
+
+    def head(self, routes: List[str]):
+        return self.route(routes=routes, method=HTTPMethods.HEAD)
+
+    def delete(self, routes: List[str]):
+        return self.route(routes=routes, method=HTTPMethods.DELETE)
+
+    def patch(self, routes: List[str]):
+        return self.route(routes=routes, method=HTTPMethods.PATCH)
+
+    def post(self, routes: List[str]):
+        return self.route(routes=routes, method=HTTPMethods.POST)
+
+    def put(self, routes: List[str]):
+        return self.route(routes=routes, method=HTTPMethods.PUT)

--- a/asyncworker/http/methods.py
+++ b/asyncworker/http/methods.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class HTTPMethods(str, Enum):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    DELETE = "DELETE"
+    PATCH = "PATCH"
+    HEAD = "HEAD"

--- a/asyncworker/http/methods.py
+++ b/asyncworker/http/methods.py
@@ -1,10 +1,12 @@
-from enum import Enum
+from enum import auto
+
+from asyncworker.options import AutoNameEnum
 
 
-class HTTPMethods(str, Enum):
-    GET = "GET"
-    POST = "POST"
-    PUT = "PUT"
-    DELETE = "DELETE"
-    PATCH = "PATCH"
-    HEAD = "HEAD"
+class HTTPMethods(AutoNameEnum):
+    GET = auto()
+    POST = auto()
+    PUT = auto()
+    DELETE = auto()
+    PATCH = auto()
+    HEAD = auto()

--- a/asyncworker/options.py
+++ b/asyncworker/options.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import List, Any
+from typing import List
 
 
 class AutoNameEnum(str, Enum):

--- a/asyncworker/rabbitmq/__init__.py
+++ b/asyncworker/rabbitmq/__init__.py
@@ -1,1 +1,3 @@
+from asyncworker.routes import AMQPRouteOptions
+
 from .message import RabbitMQMessage  # noqa: F401

--- a/asyncworker/rabbitmq/entrypoints.py
+++ b/asyncworker/rabbitmq/entrypoints.py
@@ -1,0 +1,29 @@
+from typing import List, Optional
+
+from asyncworker.entrypoints import EntrypointInterface, _extract_async_callable
+from asyncworker.routes import _AMQPRouteOptions, RoutesRegistry, AMQPRoute
+
+
+def _register_amqp_handler(
+    registry: RoutesRegistry,
+    routes: List[str],
+    options: Optional[_AMQPRouteOptions],
+):
+    def _wrap(f):
+
+        cb = _extract_async_callable(f)
+        route = AMQPRoute(handler=cb, routes=routes, options=options)
+        registry.add_amqp_route(route)
+
+        return f
+
+    return _wrap
+
+
+class AMQPRouteEntryPointImpl(EntrypointInterface):
+    def consume(
+        self,
+        routes: List[str],
+        options: Optional[_AMQPRouteOptions] = _AMQPRouteOptions(),
+    ):
+        return _register_amqp_handler(self.app.routes_registry, routes, options)

--- a/asyncworker/rabbitmq/entrypoints.py
+++ b/asyncworker/rabbitmq/entrypoints.py
@@ -1,13 +1,13 @@
 from typing import List, Optional
 
 from asyncworker.entrypoints import EntrypointInterface, _extract_async_callable
-from asyncworker.routes import _AMQPRouteOptions, RoutesRegistry, AMQPRoute
+from asyncworker.routes import AMQPRouteOptions, RoutesRegistry, AMQPRoute
 
 
 def _register_amqp_handler(
     registry: RoutesRegistry,
     routes: List[str],
-    options: Optional[_AMQPRouteOptions],
+    options: Optional[AMQPRouteOptions],
 ):
     def _wrap(f):
 
@@ -24,6 +24,6 @@ class AMQPRouteEntryPointImpl(EntrypointInterface):
     def consume(
         self,
         routes: List[str],
-        options: Optional[_AMQPRouteOptions] = _AMQPRouteOptions(),
+        options: Optional[AMQPRouteOptions] = AMQPRouteOptions(),
     ):
         return _register_amqp_handler(self.app.routes_registry, routes, options)

--- a/asyncworker/rabbitmq/entrypoints.py
+++ b/asyncworker/rabbitmq/entrypoints.py
@@ -1,5 +1,7 @@
 from typing import List, Optional
 
+from asyncworker import conf
+from asyncworker.connections import AMQPConnection
 from asyncworker.entrypoints import EntrypointInterface, _extract_async_callable
 from asyncworker.routes import AMQPRouteOptions, RoutesRegistry, AMQPRoute
 
@@ -7,12 +9,20 @@ from asyncworker.routes import AMQPRouteOptions, RoutesRegistry, AMQPRoute
 def _register_amqp_handler(
     registry: RoutesRegistry,
     routes: List[str],
+    vhost: str,
+    connection: Optional[AMQPConnection],
     options: Optional[AMQPRouteOptions],
 ):
     def _wrap(f):
 
         cb = _extract_async_callable(f)
-        route = AMQPRoute(handler=cb, routes=routes, options=options)
+        route = AMQPRoute(
+            handler=cb,
+            routes=routes,
+            vhost=vhost,
+            connection=connection,
+            options=options,
+        )
         registry.add_amqp_route(route)
 
         return f
@@ -24,6 +34,10 @@ class AMQPRouteEntryPointImpl(EntrypointInterface):
     def consume(
         self,
         routes: List[str],
+        vhost: str = conf.settings.AMQP_DEFAULT_VHOST,
+        connection: Optional[AMQPConnection] = None,
         options: Optional[AMQPRouteOptions] = AMQPRouteOptions(),
     ):
-        return _register_amqp_handler(self.app.routes_registry, routes, options)
+        return _register_amqp_handler(
+            self.app.routes_registry, routes, vhost, connection, options
+        )

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -248,5 +248,11 @@ class RoutesRegistry(UserDict):
     def add_route(self, route: Route) -> None:
         self[route.handler] = route
 
+    def add_http_route(self, route: HTTPRoute) -> None:
+        self[route.handler] = route
+
+    def add_amqp_route(self, route: AMQPRoute) -> None:
+        self[route.handler] = route
+
     def route_for(self, handler: RouteHandler) -> Route:
         return self[handler]

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -19,7 +19,7 @@ from cached_property import cached_property
 from pydantic import BaseModel, validator, root_validator
 
 from asyncworker import conf
-from asyncworker.connections import AMQPConnection
+from asyncworker.connections import Connection, AMQPConnection
 from asyncworker.http.wrapper import RequestWrapper
 from asyncworker.options import DefaultValues, RouteTypes, Actions
 from asyncworker.types.registry import TypesRegistry
@@ -75,6 +75,7 @@ class Route(Model, abc.ABC):
     type: RouteTypes
     handler: Any
     routes: List[str]
+    connection: Optional[Connection]
     options: _RouteOptions = _RouteOptions()
 
     @staticmethod
@@ -161,6 +162,7 @@ class AMQPRouteOptions(_RouteOptions):
 class AMQPRoute(Route):
     type: RouteTypes = RouteTypes.AMQP_RABBITMQ
     vhost: str = conf.settings.AMQP_DEFAULT_VHOST
+    connection: Optional[AMQPConnection]
     options: AMQPRouteOptions
 
 

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -16,7 +16,7 @@ from aiohttp import web
 from aiohttp.hdrs import METH_ALL
 from aiohttp.web_routedef import RouteDef
 from cached_property import cached_property
-from pydantic import BaseModel, validator, root_validator
+from pydantic import Extra, BaseModel, validator, root_validator
 
 from asyncworker import conf
 from asyncworker.connections import Connection, AMQPConnection
@@ -156,7 +156,8 @@ class AMQPRouteOptions(_RouteOptions):
     connection: Optional[Union[AMQPConnection, str]]
 
     class Config:
-        arbitrary_types_allowed = True
+        arbitrary_types_allowed = False
+        extra = Extra.forbid
 
 
 class AMQPRoute(Route):

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -144,7 +144,7 @@ class HTTPRoute(Route):
                 )
 
 
-class _AMQPRouteOptions(_RouteOptions):
+class AMQPRouteOptions(_RouteOptions):
     bulk_size: int = DefaultValues.BULK_SIZE
     bulk_flush_interval: int = DefaultValues.BULK_FLUSH_INTERVAL
     on_success: Actions = DefaultValues.ON_SUCCESS
@@ -161,7 +161,7 @@ class _AMQPRouteOptions(_RouteOptions):
 class AMQPRoute(Route):
     type: RouteTypes = RouteTypes.AMQP_RABBITMQ
     vhost: str = conf.settings.AMQP_DEFAULT_VHOST
-    options: _AMQPRouteOptions
+    options: AMQPRouteOptions
 
 
 class _SSERouteOptions(_RouteOptions):

--- a/docs-src/userguide/asyncworker-app/intro.rst
+++ b/docs-src/userguide/asyncworker-app/intro.rst
@@ -20,22 +20,7 @@ As instâncias dessas conexões podem ser usadas dentro do handlers, se necessá
 Definindo handlers em sua App Asyncworker
 -----------------------------------------
 
+A forma de definir um novo handler em sua app Asyncworker depende do backend que você estiver usando. Cada backend (HTTP, AMQP, etc) expõe
+uma interface para que esse registro seja feito.
 
-Nesse objeto temos um método especial chamado ``route()``. Esse método é o ponto central para registrar seus handlers. Esse mesmo método registra handlers de todos os tipos, por isso recebe um parametro para saber qual origem de estímulos fará esse handler ser chamado.
-
-Os tipos estão definidos no Enum :py:class:`asyncworker.options.RouteTypes`.
-
-
-Esse método tem a seguinte assinatura:
-
-
-.. automethod:: asyncworker.app.App.route
-  :noindex:
-
-O primeiro parâmetro tem múltiplos significados, dependento do tipo de handler que você está registrando.
-
-Por exmeplo, para um handler HTTP essa lista é lista de paths do Request HTTP que farão esse handler ser chamado. Se for um handlar RabbitMQ essa lista representa a lista de filas que esse handler estará "conectado", ou seja, a cada mensagem depositada em quaisquer uma dessas filas, esse handler será chamado.
-
-Um outro parametro obrigatório é o parametro ``type``. Ele, necessariamente, deve ser uma das opções do Enum :py:class:`asyncworker.options.RouteTypes`.
-
-Esse método deve ser usado como um decorator em funções que serão registradas como handlers da sua App.
+Para mais detalhes veja a documentação específica do backend que você quer usar: :ref:`Tipos de Handlers <handler-types>`.

--- a/docs-src/userguide/handlers/http/doc.rst
+++ b/docs-src/userguide/handlers/http/doc.rst
@@ -1,7 +1,7 @@
 
 
-Regras para criação de um handler HTTP
-======================================
+Registrando um novo handler HTTP
+=================================
 
 Todo handler HTTP deve seguir algumas regras:
 
@@ -62,7 +62,7 @@ Um exemplo de handler que usa um método HTTP qualquer:
 
 .. code-block:: python
 
-  @app.http.route(["/bla"], method="CONTINUE")
+  @app.http._route(["/bla"], method="CONTINUE")
   async def handler(...):
     pass
 
@@ -118,7 +118,7 @@ Por isso esses handlers precisam ser registrados chamando o decorator manualment
 
   h = Handler()
 
-  app.route(...)(h)
+  app.http.get(...)(h)
 
 
 .. _typed-handlers:

--- a/docs-src/userguide/handlers/http/doc.rst
+++ b/docs-src/userguide/handlers/http/doc.rst
@@ -20,7 +20,7 @@ Métodos HTTP suportados
 .. _supported-methods:
 .. versionadded:: 0.15.2
 
-Para definirmos qual método HTTP nosso handler vai responder, devemos usar um dos decorators que estão disponíveis abaixo de `app.http.*`. Atualmente temos:
+Para definirmos qual método HTTP nosso handler vai responder, devemos usar um dos decorators que estão disponíveis abaixo de ``app.http.*``. Atualmente temos:
 
 - ``@app.http.get()``
 - ``@app.http.post()``
@@ -49,6 +49,24 @@ Esses decorators recebem como parametro uma lista de paths que serão respondido
 
 
 Parametros no path podem ser definidos cercando com ``{}``, ex: ``/users/{user_id}``. Mais delathes em como receber esses valores em seu handler :ref:`aqui <handler-path-param>`.
+
+
+Usando métodos não suportados pelo asyncworker
+==============================================
+
+Eventualmente você pode precisar registrar um handler que responde por um método HTTP que não possui um decorator específico. Nesse caso você pode usar o decorator ``@app.http._route()`` para regisgtrar esse handler.
+
+Mas lembre-se que você está usando uma API interna do asyncworker e que não há garantias de que essa inteface seja mantida estável. O ideal é que o método que você precisa seja adicionado ao projeto.
+
+Um exemplo de handler que usa um método HTTP qualquer:
+
+.. code-block:: python
+
+  @app.http.route(["/bla"], method="CONTINUE")
+  async def handler(...):
+    pass
+
+
 
 
 ENVs para escolher a porta e o IP onde o server http estará escutando

--- a/docs-src/userguide/handlers/http/doc.rst
+++ b/docs-src/userguide/handlers/http/doc.rst
@@ -5,7 +5,7 @@ Regras para criação de um handler HTTP
 
 Todo handler HTTP deve seguir algumas regras:
 
- - Deve sempre ser decorato com :ref:`@app.route() <asyncworker-app-handler>`
+ - Deve sempre ser decorado com :ref:`@app.http.*() <supported-methods>`
  - Deve declarar seus parametros sempre com definição de tipos, pois é assim que o asyncworker saberá passar :ref:`parametros dinâmicos <handler-path-param>` para o handler.
  - Um handler pode não receber nenhum parâmetro. Para isso basta a assinatura do handler ser vazia.
 
@@ -14,14 +14,39 @@ Alguns objetos já são passados ao handler, caso estejam presentes em sua assin
  - Uma instância de :py:class:`asyncworker.http.wrapper.RequestWrapper`.
 
 
-Parametrização do decorator route() para handlers HTTP
-=======================================================
+Métodos HTTP suportados
+=======================
 
-Para um handler HTTP deveremos passar os seguintes parametros para o decorator ``route()``:
+.. _supported-methods:
+.. versionadded:: 0.15.2
 
-  - Lista de paths que devem estar na Request HTTP para que esse handler seja chamado;
-  - ``type=RouteTypes.HTTP``
-  - ``methods`` sendo uma lista de métodos HTTP permitidos para esse handler
+Para definirmos qual método HTTP nosso handler vai responder, devemos usar um dos decorators que estão disponíveis abaixo de `app.http.*`. Atualmente temos:
+
+- ``@app.http.get()``
+- ``@app.http.post()``
+- ``@app.http.put()``
+- ``@app.http.patch()``
+- ``@app.http.delete()``
+- ``@app.http.head()``
+
+Esses decorators recebem como parametro uma lista de paths que serão respondidos pelo handler decorado. Exemplo:
+
+.. code-block:: python
+
+
+  from aiohttp import web
+
+  from asyncworker import App
+  from asyncworker.http.decorators import parse_path
+  from asyncworker.http.wrapper import RequestWrapper
+
+  app = App()
+
+
+  @app.http.get(["/", "/other"])
+  async def handler():
+      return web.json_response({})
+
 
 Parametros no path podem ser definidos cercando com ``{}``, ex: ``/users/{user_id}``. Mais delathes em como receber esses valores em seu handler :ref:`aqui <handler-path-param>`.
 
@@ -62,7 +87,7 @@ Importante notar que como estamos lidando com um objeto ele precisará ser insta
 
   h = Handler()
 
-  @app.route(...)
+  @app.http.get(...)
   h
 
 Por isso esses handlers precisam ser registrados chamando o decorator manualmente, assim:
@@ -112,7 +137,7 @@ Um exemplo de como popular esse registry é através de um decorator aplicado di
 
       return _wrapper
 
-  @app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+  @app.http.get(["/"])
   @auth_required
   async def handler(user: User):
       return web.json_response({})
@@ -135,7 +160,7 @@ Importante notar que, primeiro o asyncworker vai procurar nosso parametro pelo n
 
 .. code-block:: python
 
-  @app.route(["/by_id/{_id}"], type=RouteTypes.HTTP, methods=["GET"])
+  @app.http.get(["/by_id/{_id}"])
   @parse_path
   async def by_id(_id: int):
       return web.json_response({})

--- a/docs-src/userguide/handlers/http/index.rst
+++ b/docs-src/userguide/handlers/http/index.rst
@@ -6,7 +6,7 @@ HTTP
 Aqui mostraremos como escrever um handler que é estimulado através de requisições HTTP.
 
 
-Um handler é simplesmete uma corotina que recebe um request wrapper (:py:class:`asyncworker.http.wrapper.RequestWrapper`) e retorna uma response (``aiohttp.web.Response``). Essa corotina passa a ser um handler "asyncworker" quando é decorada com ``@app.route()``, onde ``app`` é uma instância de ``asyncworker.App``.
+Um handler é simplesmete uma corotina que recebe um request wrapper (:py:class:`asyncworker.http.wrapper.RequestWrapper`) e retorna uma response (``aiohttp.web.Response``). Essa corotina passa a ser um handler "asyncworker" quando é decorada com :ref:`@app.http.*() <supported-methods>`, onde ``app`` é uma instância de ``asyncworker.App``.
 
 Vejamos um handler bem simples que apenas retorna ``HTTP 200 OK``.
 
@@ -15,12 +15,12 @@ Vejamos um handler bem simples que apenas retorna ``HTTP 200 OK``.
   from aiohttp import web
 
   from asyncworker.http.wrapper import RequestWrapper
-  from asyncworker import App, RouteTypes
+  from asyncworker import App
 
   app = App()
 
 
-  @app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+  @app.http.get(["/"])
   async def one_param(wrapper: RequestWrapper):
       return web.json_response({})
 

--- a/docs-src/userguide/handlers/rabbitmq/doc.rst
+++ b/docs-src/userguide/handlers/rabbitmq/doc.rst
@@ -1,25 +1,25 @@
-Parametros adicionais para o decorator route()
-----------------------------------------------
+Parametros adicionais para o decorator app.amqp.consume()
+---------------------------------------------------------
 
-Para um handler RabbitMQ o decortor ``route()`` pode receber alguns parametros adicionais.
+Para um handler RabbitMQ o decorator ``@app.amqp.consume()`` pode receber alguns parametros adicionais.
 
   - Lista de filas de onde esse handler receberá mensagens
-  - ``type=RouteTypes.AMQP_RABBITMQ``
   - ``vhost``: Indica em qual vhost as filas estatão definidas. Se não passarmos nada será usado ``vhost="/"``
-  - ``options`` pode ser um dicionário compatível com o modelo `asyncworker.routes._AMQPRouteOptions <https://github.com/b2wdigital/async-worker/blob/691549d296f7dc2f8dfc0c58452ccd1f88375847/asyncworker/routes.py#L119-L124>`_.
+  - ``options`` é uma instância do objeto :py:class:`asyncworker.rabbitmq.AMQPRouteOptions <asyncworker.routes.AMQPRouteOptions>`.
 
 Exemplo de valores para o campo options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. _rabbitmq-options:
 
-o dicionário ``options`` pode ter as seguintes chaves:
+O objeto :py:class:`AMQPRouteOptions <asyncworker.routes.AMQPRouteOptions>` pode ter os seguintes atributos:
 
-  - :py:attr:`Options.BULK_SIZE <asyncworker.options.Options.BULK_SIZE>`: Esse valor é um inteiro e diz qual será o tamanho máximo da lista que o handler vai receber, a cada vez que for chamado.
-  - :py:attr:`Options.BULK_FLUSH_INTERVAL <asyncworker.options.Options.BULK_FLUSH_INTERVAL>`: Inteiro e diz o tempo máximo que o bulk de mensagens poderá ficar com tamanho menor do que ``bulk_size``. Exemplo: Se seu handler tem um bulk_size de 4096 mensagens mas você recebe apenas 100 msg/min na fila em alguns momentos seu handler será chamado recebendo uma lista de mensagens **menor** do que 4096.
-  - :py:attr:`Options.CONNECTION_FAIL_CALLBACK <asyncworker.options.Options.CONNECTION_FAIL_CALLBACK>`: Função assíncrona que é chamada caso haja uma falha durante a conexão com o broker. Essa função recebe a exceção que ocorreu e o número de retentativas que falharam até então. O número de retentativas é zerado quando o app consegue se conectar com o broker.
-  - :py:attr:`Events.ON_SUCCESS <asyncworker.options.Events.ON_SUCCESS>`: Diz qual será a ação tomada pelo asyncworker quando uma chamada a um handler for concluída com sucesso, ou seja, o handler não lançar nenhuma exception. O Valor padrão é :py:attr:`Actions.ACK <asyncworker.options.Actions.ACK>`
-  - :py:attr:`Events.ON_EXCEPTION <asyncworker.options.Events.ON_EXCEPTION>`: Diz qual será a ação padrão quando a chamada a um handler lançar uma excação não tratada. O valor padrão é :py:attr:`Actions.REQUEUE <asyncworker.options.Actions.REQUEUE>`
+  - ``bulk_size``: Esse valor é um inteiro e diz qual será o tamanho máximo da lista que o handler vai receber, a cada vez que for chamado.
+  - ``bulk_flush_interval``: Inteiro e diz o tempo máximo que o bulk de mensagens poderá ficar com tamanho menor do que ``bulk_size``. Exemplo: Se seu handler tem um bulk_size de 4096 mensagens mas você recebe apenas 100 msg/min na fila em alguns momentos seu handler será chamado recebendo uma lista de mensagens **menor** do que 4096.
+  - ``connection_fail_callback``: Função assíncrona que é chamada caso haja uma falha durante a conexão com o broker. Essa função recebe a exceção que ocorreu e o número de retentativas que falharam até então. O número de retentativas é zerado quando o app consegue se conectar com o broker.
+  - ``on_success``: Diz qual será a ação tomada pelo asyncworker quando uma chamada a um handler for concluída com sucesso, ou seja, o handler não lançar nenhuma exception. O Valor padrão é :py:attr:`Actions.ACK <asyncworker.options.Actions.ACK>`
+  - ``on_exception``: Diz qual será a ação padrão quando a chamada a um handler lançar uma excação não tratada. O valor padrão é :py:attr:`Actions.REQUEUE <asyncworker.options.Actions.REQUEUE>`
+  - ``connection``: Recebe um objeto :py:class:`AMQPConnection <asyncworker.connections.AMQPConnection>`. Esse atributo é muito útil quando sua app se conecta a mais de um broker AMQP.
 
 
 Exemplo de um código que usa essas opções:
@@ -27,24 +27,56 @@ Exemplo de um código que usa essas opções:
 .. code-block:: python
 
   from asyncworker import App
-  from asyncworker.options import Options, Actions, Events
+  from asyncworker.options import Actions
+  from asyncworker.rabbitmq.AMQPRouteOptions
 
   async def fail_handler(e: Exception, n: int):
       print(f"error: {e}, retries {n}")
 
-  @app.route(
+  @app.amqp.consume(
       ["queue"],
-      options={
-          Options.BULK_SIZE: 1000,
-          Options.BULK_FLUSH_INTERVAL: 60,
-          Options.CONNECTION_FAIL_CALLBACK: fail_handler,
-          Events.ON_SUCCESS: Actions.ACK,
-          Events.ON_EXCEPTION: Actions.REJECT,
-      },
+      options=AMQPRouteOptions(
+          bulk_size=60,
+          bulk_flush_interval=10,
+          on_success=Actions.ACK,
+          on_exception=Actions.REJECT,
+      ),
   )
   async def _handler(messages):
       pass
 
+
+Consumindo de filas de outros virtualhosts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+É possível consumir de filas que estão em outros vistualhosts do mesmo broker. Para isso basta passar o parametro ``vhost`` para do decorator ``@app.amqp.consume()``. Exemplo:
+
+
+.. code-block:: python
+
+  from asyncworker import App
+  from asyncworker.options import Options, Actions, Events
+  from asyncworker.rabbitmq.AMQPRouteOptions
+
+  async def fail_handler(e: Exception, n: int):
+      print(f"error: {e}, retries {n}")
+
+  @app.amqp.consume(
+      ["queue"],
+      vhost="logs",
+      options=AMQPRouteOptions(
+          bulk_size=60,
+          bulk_flush_interval=10,
+          on_success=Actions.ACK,
+          on_exception=Actions.REJECT,
+      ),
+  )
+  async def _handler(messages):
+      pass
+
+
+
+Nesse caso esse handler consome a fila ``queue`` do virtualhost ``logs``.
 
 Uma nota sobre bulk_size e prefetch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -68,7 +100,7 @@ Nesse caso a ``app`` irá esperar o timeout do flush para liberar essas mensagen
 Caso queira alterar o tempo default do timeout do flush basta definir env ``ASYNCWORKER_FLUSH_TIMEOUT`` com um número que representará os segundos em que a app irá esperar para realizar o flush.
 
 Também é possível alterar o tempo do timeout do flush definindo o campo ``Options.BULK_FLUSH_INTERVAL`` do dicionário ``options`` passado como parâmetro na criação da rota.
-O valor passado para o dicionário ``options`` tem precedência sobre a variável de ambiente ``ASYNCWORKER_FLUSH_TIMEOUT``.
+O valor passado para o parametro ``options`` tem precedência sobre a variável de ambiente ``ASYNCWORKER_FLUSH_TIMEOUT``.
 
 
 
@@ -78,9 +110,9 @@ Exemplo de um código mais completo
 .. code-block:: python
 
   from typing import List
-  from asyncworker import App, RouteTypes
+  from asyncworker import App
   from asyncworker.connections import AMQPConnection
-  from asyncworker.rabbitmq.message import RabbitMQMessage
+  from asyncworker.rabbitmq import RabbitMQMessage, AMQPRouteOptions
 
 
   amqp_conn = AMQPConnection(
@@ -92,12 +124,15 @@ Exemplo de um código mais completo
 
   app = App(connections=[amqp_conn])
 
-  @app.route(["asgard/counts", "asgard/counts/errors"],
-             type=RouteTypes.AMQP_RABBITMQ,
-             vhost="fluentd")
+
+  @app.amqp.consume(
+      ["asgard/counts", "asgard/counts/errors"],
+      vhost="fluentd",
+      options=AMQPRouteOptions(bulk_size=60, bulk_flush_interval=10),
+  )
   async def drain_handler(messages: List[RabbitMQMessage]):
       for m in messages:
-        print(m)
+          print(m)
 
 
 Nesse exemplo, o handler ``drain_handler()`` recebe mensagens de ambas as filas: ``asgard/counts`` e ``asgard/counts/errors``.

--- a/docs-src/userguide/handlers/rabbitmq/index.rst
+++ b/docs-src/userguide/handlers/rabbitmq/index.rst
@@ -18,7 +18,7 @@ Isso significa que a assinatura dos seus handlers são fixas, ou seja, todos ele
     ...
 
 
-Como no caso de handlers RabitMQ é preciso ter uma conexão prévia com o servidor d e filas, precisamos criar uma instância de :py:class:`asyncworker.connections.AMQPConnection`. Essa instância deve ser passada no momento da criação de sua :ref:`Asyncworker App <asyncworker-app>`.
+Como no caso de handlers RabitMQ é preciso ter uma conexão prévia com o servidor de filas, precisamos criar uma instância de :py:class:`asyncworker.connections.AMQPConnection`. Essa instância deve ser passada no momento da criação de sua :ref:`Asyncworker App <asyncworker-app>`.
 
 Essa instância de conexão pode também ser usada dentro do handler, caso necessário.
 
@@ -31,7 +31,6 @@ Um exemplo disso é quando precisamos de um handler que lê mensagens de um fila
 
   from asyncworker import App
   from asyncworker.connections import AMQPConnection
-  from asyncworker.options import RouteTypes
   from asyncworker.rabbitmq import RabbitMQMessage
 
   amqp_conn = AMQPConnection(
@@ -44,7 +43,7 @@ Um exemplo disso é quando precisamos de um handler que lê mensagens de um fila
   app = App(connections=[amqp_conn])
 
 
-  @app.route(["original_queue"], type=RouteTypes.AMQP_RABBITMQ)
+  @app.amqp.consume(["original_queue"])
   async def handler(messages: List[RabbitMQMessage]):
       await amqp_conn.put(
           data={"dogs": ["Xablau", "Xena"]},
@@ -58,7 +57,7 @@ se a fila de destino estiver um outro virtual host, basta pegar uma nova conexã
 .. code-block:: python
 
 
-  @app.route(["original_queue"], type=RouteTypes.AMQP_RABBITMQ)
+  @app.amqp.consume(["original_queue"])
   async def handler(messages: List[RabbitMQMessage]):
       await amqp_conn["other-vhost"].put(
           data={"dogs": ["Xablau", "Xena"]},

--- a/docs-src/userguide/quickstart.rst
+++ b/docs-src/userguide/quickstart.rst
@@ -5,13 +5,13 @@ Um exemplo rápido para mostrar a ideia geral do asynworker.
 
 .. code:: python
 
-  from asyncworker import App, RouteTypes
+  from asyncworker import App
   from asyncworker.http.wrapper import RequestWrapper
 
 
   app = App()
 
-  @app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+  @app.http.get(["/"])
   async def handler(wrapper: RequestWrapper):
     return web.json_response({})
 
@@ -28,21 +28,20 @@ Consumindo de uma fila no RabbitMQ
 .. code:: python
 
 
-   from asyncworker import App, RouteTypes
+   from asyncworker import App
    from asyncworker.connections import AMQPConnection
 
 
    amqp_conn = AMQPConnection(host="127.0.0.1", user="guest", password="guest", prefetch_count=256)
    app = App(connections=[amqp_conn])
 
-   @app.route(["asgard/counts", "asgard/counts/errors"],
-              type=RouteTypes.AMQP_RABBITMQ,
+   @app.amqp.consume(["asgard/counts", "asgard/counts/errors"],
               vhost="fluentd")
    async def drain_handler(message):
        print(message)
 
 Nesse exemplo, o handler ``drain_handler()`` recebe mensagens de ambas
-as filas: ``asgard/counts`` e ``asgard/counts/errors``.
+as filas: ``asgard/counts`` e ``asgard/counts/errors``, que estão no virtualhost ``fluentd``.
 
 Se o handler lançar alguma exception, a mensagem é automaticamente
 devolvida para a fila (reject com requeue=True); Se o handler rodar sem
@@ -87,12 +86,12 @@ Recebendo dados através de requisições HTTP
 
 .. code:: python
 
-   from asyncworker import App, RouteTypes
+   from asyncworker import App
    from asynworker.http.wrapper import RequestWrapper
 
    # ...
 
-   @app.route(routes=['/', '/hello'], methods=['GET'], type=RouteTypes.HTTP)
+   @app.http.get(routes=['/', '/hello'])
    async def index(wrapper: RequestWrapper) -> web.Response:
        return web.Response(body="Hello world")
 
@@ -118,3 +117,5 @@ está no módulo ``myworker``:
 Nesse ponto sua app já estará rodando e caso você seja desconectado, um
 loop ficará tentanto reconectar. A cada erro de conexão um log de
 exception é gerado.
+
+No momento que você roda esse código (``app.run()``) todos os seus handlers registrados começam a funcionar.

--- a/examples/http_api.py
+++ b/examples/http_api.py
@@ -1,26 +1,24 @@
 from aiohttp import web
 
-from asyncworker import App, RouteTypes
+from asyncworker import App
 from asyncworker.http.decorators import parse_path
 from asyncworker.http.wrapper import RequestWrapper
 
 app = App()
 
 
-@app.route(["/", "/other"], type=RouteTypes.HTTP, methods=["GET"])
+@app.http.get(["/", "/other"])
 async def handler():
     return web.json_response({})
 
 
-@app.route(
-    ["/by_id/{_id}/other/{value}"], type=RouteTypes.HTTP, methods=["GET"]
-)
+@app.http.get(["/by_id/{_id}/other/{value}"])
 @parse_path
 async def by_id(_id: int, value: int):
     return web.json_response({"url-param-value": f"{_id}, {value}"})
 
 
-@app.route(["/one-param"], type=RouteTypes.HTTP, methods=["GET"])
+@app.http.get(["/one-param"])
 async def one_param(r: RequestWrapper):
     return web.json_response(dict(r.http_request.query))
 

--- a/examples/rabbitmq-multi-broker.py
+++ b/examples/rabbitmq-multi-broker.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from typing import List
+
+from asyncworker import App
+from asyncworker.connections import AMQPConnection
+from asyncworker.http.methods import HTTPMethods
+from asyncworker.options import Actions, Events, Options
+from asyncworker.rabbitmq import RabbitMQMessage, AMQPRouteOptions
+
+"""
+Para rodar esse exemplo precisamos de dois RabbitMQ rodando, ambos na porta default.
+Basta ajustar os endereços abaixo apontando cada conexão para o RabbitMQ correspondente.
+
+Em ambos os Rabbits deve existe uma fila com nome "queue" no vhost "/".
+"""
+
+
+amqp_conn = AMQPConnection(
+    hostname="127.0.0.1", username="guest", password="guest"
+)
+
+amqp_conn_2 = AMQPConnection(
+    hostname="172.17.0.2", username="guest", password="guest"
+)
+
+app = App(connections=[amqp_conn, amqp_conn_2])
+
+
+@app.amqp.consume(
+    ["queue"], connection=amqp_conn, options=AMQPRouteOptions(bulk_size=64)
+)
+async def _handler_broker_1(msgs: List[RabbitMQMessage]):
+    print(f"Broker 1 ({amqp_conn.hostname}): Recv: {len(msgs)}")
+    for m in msgs:
+        await amqp_conn_2["/"].put(
+            serialized_data=m.serialized_data, routing_key="queue"
+        )
+
+
+@app.amqp.consume(
+    ["queue"], connection=amqp_conn_2, options=AMQPRouteOptions(bulk_size=128)
+)
+async def _handler_roker_2(msgs: List[RabbitMQMessage]):
+    print(f"Broker 2 ({amqp_conn_2.hostname}): Recv: {len(msgs)}")
+
+
+@app.run_every(1)
+async def produce(app: App):
+    for _ in range(32):
+        await amqp_conn.put(data={"msg": "Broker 1"}, routing_key="queue")
+        await amqp_conn_2.put(data={"msg": "broker 2"}, routing_key="queue")
+
+
+app.run()

--- a/examples/rabbitmq.py
+++ b/examples/rabbitmq.py
@@ -1,9 +1,9 @@
+from datetime import datetime
 from typing import List
 
 from asyncworker import App
 from asyncworker.connections import AMQPConnection
-from asyncworker.options import RouteTypes, Options
-from asyncworker.rabbitmq import RabbitMQMessage
+from asyncworker.rabbitmq import RabbitMQMessage, AMQPRouteOptions
 
 amqp_conn = AMQPConnection(
     hostname="127.0.0.1", username="guest", password="guest", prefetch=1024
@@ -12,11 +12,11 @@ amqp_conn = AMQPConnection(
 app = App(connections=[amqp_conn])
 
 
-@app.route(
-    ["queue"], type=RouteTypes.AMQP_RABBITMQ, options={Options.BULK_SIZE: 512}
+@app.amqp.consume(
+    ["queue"], options=AMQPRouteOptions(bulk_size=60, bulk_flush_interval=10)
 )
-async def handler(messages: List[RabbitMQMessage]):
-    print(f"Received {len(messages)} messages")
+async def _handler(msgs: List[RabbitMQMessage]):
+    print(f"Recv {len(msgs)} {datetime.now().isoformat()}")
 
 
 @app.run_every(1)

--- a/examples/rabbitmq.py
+++ b/examples/rabbitmq.py
@@ -13,7 +13,8 @@ app = App(connections=[amqp_conn])
 
 
 @app.amqp.consume(
-    ["queue"], options=AMQPRouteOptions(bulk_size=60, bulk_flush_interval=10)
+    ["queue"],
+    options=AMQPRouteOptions(bulk_size=1024 * 8, bulk_flush_interval=10),
 )
 async def _handler(msgs: List[RabbitMQMessage]):
     print(f"Recv {len(msgs)} {datetime.now().isoformat()}")

--- a/itests/test_rabbitmq_consumer.py
+++ b/itests/test_rabbitmq_consumer.py
@@ -1,5 +1,4 @@
 import asyncio
-from http import HTTPStatus
 
 from asynctest import TestCase
 
@@ -37,7 +36,7 @@ class RabbitMQConsumerTest(TestCase):
         """
         message = {"key": "value"}
 
-        @self.app.route([self.queue_name], type=RouteTypes.AMQP_RABBITMQ)
+        @self.app.amqp.consume([self.queue_name])
         async def handler(messages):
             global successful_message_value_is_equal
             successful_message_value_is_equal = (
@@ -61,7 +60,7 @@ class RabbitMQConsumerTest(TestCase):
         O handler confirmará a mensagem na segunda tentativa (`msg.ack()`)
         """
 
-        @self.app.route([self.queue_name], type=RouteTypes.AMQP_RABBITMQ)
+        @self.app.amqp.consume([self.queue_name])
         async def other_handler(messages):
             global handler_with_requeue_called
             if handler_with_requeue_called > 0:
@@ -89,7 +88,7 @@ class RabbitMQConsumerTest(TestCase):
         Temos que conferir que o handler foi chamado
         """
 
-        @self.app.route([self.queue_name], type=RouteTypes.AMQP_RABBITMQ)
+        @self.app.amqp.consume([self.queue_name])
         async def other_handler(messages):
             global handler_without_requeue_called
             handler_without_requeue_called += 1

--- a/itests/test_rabbitmq_consumer.py
+++ b/itests/test_rabbitmq_consumer.py
@@ -1,4 +1,5 @@
 import asyncio
+from http import HTTPStatus
 
 from asynctest import TestCase
 
@@ -9,6 +10,9 @@ consume_callback_shoud_not_be_called = False
 handler_with_requeue_called = 0
 handler_without_requeue_called = 0
 successful_message_value_is_equal = False
+
+message_processed_multiple_connections = False
+message_processed_other_vhost = False
 
 
 class RabbitMQConsumerTest(TestCase):
@@ -117,3 +121,70 @@ class RabbitMQConsumerTest(TestCase):
         )
         await asyncio.sleep(5)
         self.assertFalse(consume_callback_shoud_not_be_called)
+
+
+class AMQPConsumerTestWithAdditionalParameters(TestCase):
+    maxDiff = None
+
+    async def setUp(self):
+        from aiohttp import ClientSession, BasicAuth
+
+        client = ClientSession()
+
+        await client.put(
+            "http://127.0.0.1:15672/api/vhosts/logs",
+            json={},
+            auth=BasicAuth(login="guest", password="guest"),
+        )
+        resp = await client.put(
+            "http://127.0.0.1:15672/api/permissions/logs/guest",
+            json={"configure": ".*", "write": ".*", "read": ".*"},
+            auth=BasicAuth(login="guest", password="guest"),
+        )
+
+    async def test_consume_one_message_app_with_multiple_connections(self):
+        conn = AMQPConnection(
+            hostname="127.0.0.1", username="guest", password="guest", prefetch=1
+        )
+        conn_2 = AMQPConnection(
+            hostname="127.0.0.1:5673",
+            username="guest",
+            password="guest",
+            prefetch=1,
+        )
+        await conn["/"].connection._connect()
+        await conn["/"].connection.channel.queue_declare("queue")
+        await conn["/"].put(data={"num": 42}, routing_key="queue")
+
+        app = App(connections=[conn, conn_2])
+
+        @app.amqp.consume(["queue"], connection=conn)
+        async def handler(msgs):
+            global message_processed_multiple_connections
+            message_processed_multiple_connections = True
+
+        await app.startup()
+        await asyncio.sleep(1)
+        await app.shutdown()
+        self.assertTrue(message_processed_multiple_connections)
+
+    async def test_consume_from_other_vhost(self):
+        conn = AMQPConnection(
+            hostname="127.0.0.1", username="guest", password="guest", prefetch=1
+        )
+
+        await conn["logs"].connection._connect()
+        await conn["logs"].connection.channel.queue_declare("queue")
+        await conn["logs"].put(data={"num": 42}, routing_key="queue")
+
+        app = App(connections=[conn])
+
+        @app.amqp.consume(["queue"], vhost="logs")
+        async def handler(msgs):
+            global message_processed_other_vhost
+            message_processed_other_vhost = True
+
+        await app.startup()
+        await asyncio.sleep(1)
+        await app.shutdown()
+        self.assertTrue(message_processed_other_vhost)

--- a/tests/http/test_http_decorators.py
+++ b/tests/http/test_http_decorators.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 from aiohttp import web
 from asynctest import mock, TestCase
 
-from asyncworker import App, RouteTypes
+from asyncworker import App
 from asyncworker.http import decorators
 from asyncworker.http.decorators import parse_path
 from asyncworker.testing import HttpClientContext
@@ -13,16 +13,12 @@ class HTTPDecoratorsTest(TestCase):
     async def setUp(self):
         self.app = App()
 
-        @self.app.route(
-            ["/get_by_id/{_id}"], type=RouteTypes.HTTP, methods=["POST"]
-        )
+        @self.app.http.post(["/get_by_id/{_id}"])
         @parse_path
         async def get_by_id(_id: int):
             return web.json_response({"numero": _id})
 
-        @self.app.route(
-            ["/param/{p1}/{p2}"], type=RouteTypes.HTTP, methods=["POST"]
-        )
+        @self.app.http.post(["/param/{p1}/{p2}"])
         @parse_path
         async def path_multiple_params(p1: int, p2: int):
             return web.json_response({"p1": p1, "p2": p2})

--- a/tests/http/test_metrics_endpoint.py
+++ b/tests/http/test_metrics_endpoint.py
@@ -22,9 +22,7 @@ class MetricsEndpointTest(TestCase):
     async def setUp(self):
         self.METRICS_PATH = "/metrics-2"
         self.app = App()
-        self.app.route(
-            [self.METRICS_PATH], type=RouteTypes.HTTP, methods=["GET"]
-        )(metrics_route_handler)
+        self.app.http.get([self.METRICS_PATH])(metrics_route_handler)
 
     async def test_metrics_namespace(self):
         def _check_metrics_cant_override_namespace(metric, metric_name):
@@ -101,7 +99,7 @@ class MetricsEndpointTest(TestCase):
         metric_name = "myapp_example_counter"
         counter = Counter(metric_name, "Um contador simples")
 
-        @self.app.route(["/foo"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/foo"])
         async def _handler():
             counter.inc()
             return web.json_response({})
@@ -127,7 +125,7 @@ class MetricsEndpointTest(TestCase):
         metric_name = "myapp_example_gauge"
         gauge = Gauge(metric_name, "um Gauge simples", registry=REGISTRY)
 
-        @self.app.route(["/foo/{value}"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/foo/{value}"])
         @parse_path
         async def _handler(value: int):
             gauge.inc(value)
@@ -157,7 +155,7 @@ class MetricsEndpointTest(TestCase):
             metric_name, "um Histogram simples", registry=REGISTRY
         )
 
-        @self.app.route(["/foo/{value}"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/foo/{value}"])
         @parse_path
         async def _handler(value: int):
             histogram.observe(value)

--- a/tests/metrics/test_http_metrics.py
+++ b/tests/metrics/test_http_metrics.py
@@ -22,10 +22,8 @@ class HTTPMetricsTests(TestCase):
             "asyncworker.metrics.aiohttp_resources.metrics"
         ).start()
 
-        @self.app.route(
-            routes=[self.route_path],
-            type=RouteTypes.HTTP,
-            methods=[self.route_method],
+        @self.app.http._route(
+            routes=[self.route_path], method=self.route_method
         )
         async def handler(request):
             metrics.requests_in_progress.labels.assert_called_once_with(

--- a/tests/signals/handlers/test_http.py
+++ b/tests/signals/handlers/test_http.py
@@ -102,7 +102,7 @@ class HTTPServerTests(asynctest.TestCase):
         Tests if a response is correctly handled, Starts a real aiohttp server
         """
 
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def index():
             return web.json_response({"OK": True})
 
@@ -136,7 +136,7 @@ class HTTPServerTests(asynctest.TestCase):
             reload(conf)
             with mock.patch.object(routes, "conf", conf):
 
-                @app.route(["/metrics"], type=RouteTypes.HTTP, methods=["GET"])
+                @app.http.get(["/metrics"])
                 async def _h():
                     return web.json_response({})
 
@@ -152,11 +152,7 @@ class HTTPServerTests(asynctest.TestCase):
 
         app = App()
 
-        @app.route(
-            [settings.METRICS_ROUTE_PATH],
-            type=RouteTypes.HTTP,
-            methods=["POST"],
-        )
+        @app.http.post([settings.METRICS_ROUTE_PATH])
         async def _h():
             return web.json_response({"OK": True})
 
@@ -172,7 +168,7 @@ class HTTPServerTests(asynctest.TestCase):
         one parameter and does not have any type annotations
         """
 
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def handler():
             return web.json_response({"OK": True})
 
@@ -186,7 +182,7 @@ class HTTPServerTests(asynctest.TestCase):
                 self.assertEqual({"OK": True}, await resp.json())
 
     async def test_add_registry_to_all_requests(self):
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def handler(wrapper: RequestWrapper):
             request = wrapper.http_request
             registry: TypesRegistry = request["types_registry"]
@@ -216,7 +212,7 @@ class HTTPServerTests(asynctest.TestCase):
 
             return _wrapper
 
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         @insert_user_into_type_registry
         async def handler(user: User):
             return web.json_response({"name": user.name})
@@ -257,7 +253,7 @@ class HTTPServerTests(asynctest.TestCase):
 
             return _wrapper
 
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         @insert_account_into_type_registry
         @insert_user_into_type_registry
         async def handler(user: User, account: Account):
@@ -290,7 +286,7 @@ class HTTPServerTests(asynctest.TestCase):
 
             return _wrapper
 
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         @my_decorator
         async def handler(wrapper: RequestWrapper):
             return web.json_response({"num": wrapper.http_request.query["num"]})
@@ -306,7 +302,7 @@ class HTTPServerTests(asynctest.TestCase):
                 self.assertEqual({"num": "42"}, resp_data)
 
     async def test_ignores_return_annotation_when_resolving_parameters(self):
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def handler(wrapper: RequestWrapper) -> web.Response:
             return web.json_response({"num": wrapper.http_request.query["num"]})
 
@@ -321,7 +317,7 @@ class HTTPServerTests(asynctest.TestCase):
                 self.assertEqual({"num": "42"}, resp_data)
 
     async def test_handler_can_receive_aiohttp_request(self):
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def handler(request: web.Request) -> web.Response:
             return web.json_response({"num": request.query["num"]})
 
@@ -342,7 +338,7 @@ class HTTPServerTests(asynctest.TestCase):
 
             return _wrapper
 
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         @my_decorator
         async def handler(wrapper: RequestWrapper):
             return web.json_response({"num": wrapper.http_request.query["num"]})

--- a/tests/signals/handlers/test_rabbitmq.py
+++ b/tests/signals/handlers/test_rabbitmq.py
@@ -120,7 +120,7 @@ class AMQPTests(asynctest.TestCase):
         )
         app = App(connections=[conn1, conn2])
 
-        @app.route(routes=["a_queue_name"], type=RouteTypes.AMQP_RABBITMQ)
+        @app.amqp.consume(routes=["a_queue_name"])
         async def mock_handler(*args, **kwargs):
             pass
 
@@ -132,7 +132,7 @@ class AMQPTests(asynctest.TestCase):
     ):
         app = App(connections=[])
 
-        @app.route(routes=["a_queue_name"], type=RouteTypes.AMQP_RABBITMQ)
+        @app.amqp.consume(routes=["a_queue_name"])
         async def mock_handler(*args, **kwargs):
             pass
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -189,7 +189,7 @@ class AppTests(asynctest.TestCase):
 
         app = App()
 
-        @app.http.route(["/"], method=HTTPMethods.GET)
+        @app.http._route(["/"], method=HTTPMethods.GET)
         async def _h():
             return web.json_response({})
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,6 +9,7 @@ from asynctest import Mock, CoroutineMock, patch, call
 from asyncworker.app import App
 from asyncworker.connections import AMQPConnection
 from asyncworker.exceptions import InvalidConnection
+from asyncworker.http import HTTPMethods
 from asyncworker.options import RouteTypes, DefaultValues, Options
 from asyncworker.routes import AMQPRoute
 from asyncworker.task_runners import ScheduledTaskRunner
@@ -188,7 +189,7 @@ class AppTests(asynctest.TestCase):
 
         app = App()
 
-        @app.http.route(["/"], method="GET")
+        @app.http.route(["/"], method=HTTPMethods.GET)
         async def _h():
             return web.json_response({})
 
@@ -232,56 +233,56 @@ class AppTests(asynctest.TestCase):
 
         @app.http.delete(["/"])
         async def _handler():
-            return web.json_response({"DELETE": True})
+            return web.json_response({HTTPMethods.DELETE: True})
 
         async with HttpClientContext(app) as client:
             resp = await client.delete("/")
             self.assertEqual(HTTPStatus.OK, resp.status)
 
             data = await resp.json()
-            self.assertEqual({"DELETE": True}, data)
+            self.assertEqual({HTTPMethods.DELETE: True}, data)
 
     async def test_http_patch_decorator(self):
         app = App()
 
         @app.http.patch(["/"])
         async def _handler():
-            return web.json_response({"PATCH": True})
+            return web.json_response({HTTPMethods.PATCH: True})
 
         async with HttpClientContext(app) as client:
             resp = await client.patch("/", json={})
             self.assertEqual(HTTPStatus.OK, resp.status)
 
             data = await resp.json()
-            self.assertEqual({"PATCH": True}, data)
+            self.assertEqual({HTTPMethods.PATCH: True}, data)
 
     async def test_http_post_decorator(self):
         app = App()
 
         @app.http.post(["/"])
         async def _handler():
-            return web.json_response({"POST": True})
+            return web.json_response({HTTPMethods.POST: True})
 
         async with HttpClientContext(app) as client:
             resp = await client.post("/", json={})
             self.assertEqual(HTTPStatus.OK, resp.status)
 
             data = await resp.json()
-            self.assertEqual({"POST": True}, data)
+            self.assertEqual({HTTPMethods.POST: True}, data)
 
     async def test_http_put_decorator(self):
         app = App()
 
         @app.http.put(["/"])
         async def _handler():
-            return web.json_response({"PUT": True})
+            return web.json_response({HTTPMethods.PUT: True})
 
         async with HttpClientContext(app) as client:
             resp = await client.put("/", json={})
             self.assertEqual(HTTPStatus.OK, resp.status)
 
             data = await resp.json()
-            self.assertEqual({"PUT": True}, data)
+            self.assertEqual({HTTPMethods.PUT: True}, data)
 
 
 class AppConnectionsTests(asynctest.TestCase):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3,7 +3,7 @@ from asynctest import CoroutineMock, TestCase
 
 from asyncworker import RouteTypes, App
 from asyncworker.http.wrapper import RequestWrapper
-from asyncworker.options import DefaultValues, Actions
+from asyncworker.options import Actions
 from asyncworker.routes import (
     call_http_handler,
     RoutesRegistry,
@@ -223,7 +223,7 @@ class HTTPRouteRegisterTest(TestCase):
 
     async def test_handler_receives_request_object(self):
         """
-        Certifica que um decorator customizado pode receber 
+        Certifica que um decorator customizado pode receber
         uma instânccia de aiohttp.web.Request
         """
         app = App()
@@ -247,7 +247,7 @@ class HTTPRouteRegisterTest(TestCase):
 
     async def test_custom_decorator_receives_request_wrapper(self):
         """
-        Certifica que um decorator customizado pode receber 
+        Certifica que um decorator customizado pode receber
         uma instância de asyncworker.http.wrapper.RequestWrapper
         """
         app = App()
@@ -381,7 +381,7 @@ class AMQPRouteRegiterTest(TestCase):
 
     async def test_raises_if_handler_is_not_coroutine(self):
         """
-        Certifica que um decorator customizado pode receber 
+        Certifica que um decorator customizado pode receber
         uma instânccia de aiohttp.web.Request
         """
         app = App()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -371,7 +371,7 @@ class AMQPRouteRegiterTest(TestCase):
 
         options = AMQPRouteOptions(
             bulk_size=1024,
-            bulk_flush_intereval=10,
+            bulk_flush_interval=10,
             on_success=Actions.ACK,
             on_exception=Actions.REJECT,
         )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -9,7 +9,7 @@ from asyncworker.routes import (
     RoutesRegistry,
     HTTPRoute,
     AMQPRoute,
-    _AMQPRouteOptions,
+    AMQPRouteOptions,
 )
 from asyncworker.testing import HttpClientContext
 
@@ -103,7 +103,7 @@ class RoutesRegistryTests(TestCase):
         route = AMQPRoute(
             handler=CoroutineMock(),
             routes=["queue1", "queue2"],
-            options=_AMQPRouteOptions(),
+            options=AMQPRouteOptions(),
         )
 
         self.routes_registry.add_amqp_route(route)
@@ -364,7 +364,7 @@ class AMQPRouteRegiterTest(TestCase):
     async def test_register_handler_with_options(self):
         app = App()
 
-        options = _AMQPRouteOptions(
+        options = AMQPRouteOptions(
             bulk_size=1024,
             bulk_flush_intereval=10,
             on_success=Actions.ACK,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -151,7 +151,7 @@ class HTTPRouteRegisterTest(TestCase):
 
         handler = MyHandler()
 
-        app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])(handler)
+        app.http.get(["/"])(handler)
 
         async with HttpClientContext(app) as client:
             resp = await client.get("/")
@@ -209,7 +209,7 @@ class HTTPRouteRegisterTest(TestCase):
         handler = MyHandler()
 
         with self.assertRaises(TypeError):
-            app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])(handler)
+            app.http.get(["/"])(handler)
 
     async def test_raise_if_object_is_not_callable_new_decorator(self):
         app = App()
@@ -235,7 +235,7 @@ class HTTPRouteRegisterTest(TestCase):
 
             return _wrap
 
-        @app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @app.http.get(["/"])
         @_deco
         async def handler(wrapper: RequestWrapper):
             req = wrapper.http_request
@@ -259,7 +259,7 @@ class HTTPRouteRegisterTest(TestCase):
 
             return _wrap
 
-        @app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @app.http.get(["/"])
         @_deco
         async def handler(wrap: RequestWrapper):
             return web.json_response(dict(wrap.http_request.query.items()))
@@ -290,7 +290,7 @@ class AMQPRouteRegiterTest(TestCase):
 
         handler = MyHandler()
 
-        app.route(["/"], type=RouteTypes.AMQP_RABBITMQ)(handler)
+        app.amqp.consume(["/"])(handler)
 
         self.assertEqual(1, len(app.routes_registry.amqp_routes))
         self.assertEqual(
@@ -315,7 +315,7 @@ class AMQPRouteRegiterTest(TestCase):
             handler.__call__, app.routes_registry.amqp_routes[0].handler
         )
 
-    async def test_raise_if_object_is_not_callable_register_with_app_route(
+    async def test_raise_if_object_is_not_callable_register_with_app_amqp_consume(
         self
     ):
         app = App()
@@ -326,7 +326,7 @@ class AMQPRouteRegiterTest(TestCase):
         handler = MyHandler()
 
         with self.assertRaises(TypeError):
-            app.route(["/"], type=RouteTypes.AMQP_RABBITMQ)(handler)
+            app.amqp.consume(["/"])(handler)
 
     async def test_raise_if_object_is_not_callable_register_with_amqp_route_register(
         self
@@ -433,6 +433,6 @@ class AMQPRouteRegiterTest(TestCase):
             return web.json_response(dict(req.query.items()))
 
         with self.assertRaises(TypeError) as ex:
-            app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])(handler)
+            app.http.get(["/"])(handler)
 
-        self.assertTrue("handler must be a coroutine" in ex.exception.args[0])
+        self.assertTrue("handler must be async" in ex.exception.args[0])

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -11,7 +11,7 @@ from asyncworker.testing import http_client, HttpClientContext
 global_app = App()
 
 
-@global_app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+@global_app.http.get(["/"])
 async def _h():
     return web.json_response({})
 
@@ -34,7 +34,7 @@ class HttpClientTestCaseDecoratorTest(TestCase):
         self.assertEqual(HTTPStatus.OK, resp.status)
 
     async def test_client_can_perform_http_requests(self):
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def index(request):
             return web.json_response({"OK": True})
 
@@ -59,7 +59,7 @@ class HttpClientTestCaseDecoratorTest(TestCase):
         self.assertEqual([42, 10], [rv[1], rv[2]])
 
     async def test_server_is_closed_if_handler_raises_exception(self):
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def index(request):
             return web.json_response({"OK": True})
 
@@ -83,7 +83,7 @@ class HttpClientContextManagerTest(TestCase):
         self.app = App()
 
     async def test_client_can_perform_requests(self):
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def index(request):
             return web.json_response({"OK": True})
 
@@ -100,7 +100,7 @@ class HttpClientContextManagerTest(TestCase):
         fazê-lo passar de forma consistente.
         """
 
-        @self.app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+        @self.app.http.get(["/"])
         async def index(request):
             return web.json_response({"OK": True})
 


### PR DESCRIPTION
Closes #157 
Closes #182


## Ideia principal

A ideia principal aqui é sair de um handler assim:

```python
@app.route(
    ["queue"],
    type=RouteTypes.AMQP_RABBITMQ,
    options={
        Options.BULK_SIZE: 1024,
        Options.BULK_FLUSH_INTERVAL: 120,
        "on_success": Actions.ACK,
    },
)
async def handler(messages):
    pass
```

para

```python
@app.amqp.consume(
    ["queue"],
    options=AMQPRouteOptions(
        bulk_size=1024,
        bulk_flush_intereval=120,
        on_success=Actions.ACK,
        on_exception=Actions.REJECT,
    ),
)
async def handler(messages):
    pass

```

Aqui estamos basicamente trocando um interface genérica (`@app.route()`) por algumas interfaces específicas e que podem ser evoluídas de forma independente. Outro ponto importante é que na segunda forma de escrever o handler temos a validação do pydantic já em ação, que vai validar os campos de quaisquer objetos que eventualmente passemos para esses decorators.

Esse PR traz um exemplo, já funcional, de como isso poderá ser.

## Ideia principal

A ideia aqui é começar uma implementação que deprecia o uso do `@app.route()` e cria novos decorators, mais específicos para cada "backend" suportado pelo asyncworker.

Os novos decorators estão dentro de "namespaces" que já dizem sobre o que esses decorators são. Os namespaces são exatamente os backends suportados pelo asyncworker, O que temos hoje são: `http`, `amqp` e `sse`.

A implementação feita aqui tem como objetivo (quando completa) apenas "trocar" o uso do `@app.route()`, melhorias estão anotadas logo abaixo na seção "Ideias".

**Importante**: 
 - A implementaçao que temos aqui não faz uso do `Route.factory()` o que nos dá a vantagem de  não usar construções dinâmicas como `HTTPRoute(**data)`, o que vai nos ajudar um pouco na precisão da análise estática também.
 - Essa implementação traz o início da possibilidade de não expor o enum `asyncworker.options.RouteTypes`. Isso também facilitará a adição de novos backends (#225) sem mexer no core do asyncworker.

## O que temos

- `@app.http.get()` para registrar rotas `HTTP GET`;
- `@app.amqp.consume()` para registrar novos consumidores AMQP.

## O que falta

- [x] ~Implementar novos decorators do namespace `http` para todos os outros métodos possíveis. Hoje o asyncworker ja á valida isso e os métodos possívels são `aiohttp.hdrs.METH_ALL`.~ Teremos um decorator pra cada um desses métodos. Vamos fazer apenas para os métodos principais, quem precisar de outros métodos pode usar o `@app.http.route()`; (
4fdd275)
- [x] Documentar que para usar outros métodos Http é preciso usar o `@app.http.route()`. Mas deixar claro que esse não é o recomendado. Talvez valha a pena renomear para `_route()` para deixar claro que é uma interface interna; (80adb23a99783275579a555a831415071fa669df)
- [x] Mudar a assinatura do `route()` pra receber o Enum dos métodos Http; https://github.com/b2wdigital/async-worker/pull/224#issuecomment-683223045 (80adb23a99783275579a555a831415071fa669df)
- [x] Documentar os novos decorators `@app.http.*` e `@app.amqp.consume()`  (6e63d81);
- [x] Atualizar documentação para todos os exemplos usarem os novos decorators (`@app.http.*` e `@app.amqp.consume()`); e9bfce6
- [x] Avisar do depreciamento do `@app.routes()` e será removido em alguma versão major futura; Podemos até linkar com a #227. A doc do `@app.route()` está em `docs-src/userguide/asyncworker-app/intro.rst#definindo-handlers-em-sua-app-asyncworker`; e9bfce6
- [x] ~Checar que o `AMQPOptions` está funcionando corretamente. Conferir que as sub-opções estão sendo efetivamente usadas; O parametro `connection_fail_calback` parece não estar funcionando;~ Está OK. Esse método só é chamado quando há falha de connection failed.
- [x] Adicionar parametro `vhost` ao `@app.amqp.consume()`; Ficará: `consume(queues: List[str], vhost: str, options: AMQPRouteOptions)`; 0b9dae3
- [x] Adicionar o parametro `connection` ao `@app.amqp.consume()`; 0b9dae3
- [x] ~Conferir como está atualmente o comportamento de uma app que recebe múltiplas conexões ao mesmo tempo. Como um handler seleciona uma dessas conexões para fazer o consume()?~ https://github.com/b2wdigital/async-worker/pull/224#issuecomment-683173283 Isso tem relação com o #61. Temos que ver como isso está e projetar isso aqui no novo decorator. Possivelmente teremos essa assinatural? `consume(queues: List[str], vhost: str = "/", connection: Optional[AMQPConnection], options: Optional[AMQPRouteOptions])`;
- [x] Expor `AMQPOptions` em vez de `_AMQPoptions`; (84e1656)
- [x] Criar constantes para os métodos HTTP (14cf35c)
- [x] Atualizar documentação para todos os exemplos usarem as constantes dos métodos HTTP;
- [x] Atualizar os testes para usar as constantes dos métodos HTTP (67ddb91);
- [x] Atualizar os testes para usarem os novos decorators; 044ba4c
- [x] Ajustar a cobertura dos testes. Com a mudança nos testes para sempre usarem os novos decorators (044ba4c) a cobertura abaixou. c144a52
- [x] ~Implementar suporte para o backend `sse`.~ Removeremos essa implementação (que é experimental) no #227.


## Ideias

Aqui estão algumas ideias que não necessariamente precisam ser implementadas aqui nesse PR.

As properties (que definem os "namespace") retornam um novo objeto que é quem efetivamente tem os decorators. Esse objeto recebe a instância de `App` como parametro no construtor, mas isso só acontece pois é o próprio `App` quem acumula as rotas registradas. Penso que o melhor seria remover o `routes_registry` de dentro do `App` e colocar um `routes_registry` dentro de cada implementação de backend (`asyncworker/signal/handlers/*`).
