### PR TITLE
Instala libxml2-dev e xslt-dev para o Github Actions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,6 +22,8 @@ jobs:
           - 5672:5672
           - 15672:15672
     steps:
+      - name: install libxml2-dev
+        run: sudo apt-get install libxml2-dev libxslt-dev
       - name: checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Agora pelo menos o `pipenv install --dev` funciona no python 3.9. 🎉 

Ainda falta ajustar os testes, mas faremos isso depois. =D