### PR TITLE
Feature/install release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,9 +8,19 @@ categories:
   - title: 'Documentação'
     label: 'docs'
 change-template: '- #$NUMBER $TITLE (@$AUTHOR)'
+version-resolver:
+  minor:
+    labels:
+      - 'breaking-change'
+  patch:
+    labels:
+      - 'feature'
+      - 'bug'
 template: |
   ## Changelog
 
   $CHANGES
 
   Docs: https://b2wdigital.github.io/async-worker/
+  Commits: https://github.com/b2wdigital/async-worker/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+  Tag: https://github.com/b2wdigital/async-worker/releases/tag/$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,14 @@
+name: release-drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Com esse PR o release-drafter vai sugerir a próxima versão. Como ainda estamos um pouco longe de termos uma versão `1.0` a configuração está a seguinte:

- PRs com labels `bug` e `feature` aumentam o `patch` version;
- PRs com label `breaking-change` aumentam o `minor` version.

O `major` version nunca é aumentado. Dessa forma ficamos de acordo com o que temos na documenação oficial: https://b2wdigital.github.io/async-worker/versions.html