### PR TITLE
Remove wheel publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         run: pip install twine==3.2.0
 
       - name: Generate Packages
-        run: python setup.py sdist wheel
+        run: python setup.py sdist
 
       - name: Twine check
         run: twine check dist/*


### PR DESCRIPTION
O Relase do binário do codeclimate está quebrado. O arquivo `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64` foi publicado como um binário do MacOS.

```
 file test-reporter-latest-linux-amd64 
test-reporter-latest-linux-amd64: Mach-O 64-bit x86_64 executable
```
A github action que usamos (https://github.com/paambaati/codeclimate-action) pega sempre a versão `latest`, ou seja, está pegando a versão quebrada. Já existe um PR pra fazer ser possível escolher a versão do runner (assim um build quebrado por parte do codeclimate não atrapalhará tanto da próxima vez). O PR está aqui: https://github.com/paambaati/codeclimate-action/pull/276

Enquanto o PR não for mergeado ou o codeclimate não corrigir o build quebrado (https://github.com/codeclimate/test-reporter/issues/449) não poderemos mergar PRs. A não ser que mudemos nossos workflows e baixemos os binparios manualmente, o que não queremos fazer. =D