### PR TITLE
Nova interface para decorators de handlers

### DIFF
--- a/asyncworker/__init__.py
+++ b/asyncworker/__init__.py
@@ -1,5 +1,3 @@
-from functools import wraps as __wraps
-
 from asyncworker.app import App
 from asyncworker.options import (  # noqa: F401
     Options,

--- a/asyncworker/__init__.py
+++ b/asyncworker/__init__.py
@@ -1,3 +1,5 @@
+from functools import wraps as __wraps
+
 from asyncworker.app import App
 from asyncworker.options import (  # noqa: F401
     Options,

--- a/asyncworker/decorators.py
+++ b/asyncworker/decorators.py
@@ -1,7 +1,7 @@
 def wraps(original_handler):
     """
-    A ideia desse decorator que fazer com que a assinatura da função original
-    "suba" até o último decorator, que deverá ser sempre um registrador do 
+    Esse decorator faz com que a assinatura da função original
+    "suba" até o último decorator, que deverá ser sempre um registrador do
     próprio asyncworker. ex:
     @app.http.get(...)
     @deco1
@@ -9,7 +9,7 @@ def wraps(original_handler):
     async def handler(...)
         pass
 
-    Nesse caso, os decorators `@deco1` e `@deco2` devem, *necessariamente* 
+    Nesse caso, os decorators `@deco1` e `@deco2` devem, *necessariamente*
     fazer uso desse `@wraps()`
     """
 

--- a/asyncworker/decorators.py
+++ b/asyncworker/decorators.py
@@ -14,9 +14,9 @@ def wraps(original_handler):
     """
 
     def _wrap(deco):
-        deco.__original_annotations__ = getattr(
+        deco.asyncworker_original_annotations = getattr(
             original_handler,
-            "__original_annotations__",
+            "asyncworker_original_annotations",
             original_handler.__annotations__,
         )
         return deco

--- a/asyncworker/decorators.py
+++ b/asyncworker/decorators.py
@@ -1,4 +1,18 @@
 def wraps(original_handler):
+    """
+    A ideia desse decorator que fazer com que a assinatura da função original
+    "suba" até o último decorator, que deverá ser sempre um registrador do 
+    próprio asyncworker. ex:
+    @app.http.get(...)
+    @deco1
+    @deco2
+    async def handler(...)
+        pass
+
+    Nesse caso, os decorators `@deco1` e `@deco2` devem, *necessariamente* 
+    fazer uso desse `@wraps()`
+    """
+
     def _wrap(deco):
         if hasattr(original_handler, "__original_annotations__"):
             deco.__original_annotations__ = (

--- a/asyncworker/decorators.py
+++ b/asyncworker/decorators.py
@@ -1,0 +1,11 @@
+def wraps(original_handler):
+    def _wrap(deco):
+        if hasattr(original_handler, "__original_annotations__"):
+            deco.__original_annotations__ = (
+                original_handler.__original_annotations__
+            )
+        else:
+            deco.__original_annotations__ = original_handler.__annotations__
+        return deco
+
+    return _wrap

--- a/asyncworker/decorators.py
+++ b/asyncworker/decorators.py
@@ -14,12 +14,11 @@ def wraps(original_handler):
     """
 
     def _wrap(deco):
-        if hasattr(original_handler, "__original_annotations__"):
-            deco.__original_annotations__ = (
-                original_handler.__original_annotations__
-            )
-        else:
-            deco.__original_annotations__ = original_handler.__annotations__
+        deco.__original_annotations__ = getattr(
+            original_handler,
+            "__original_annotations__",
+            original_handler.__annotations__,
+        )
         return deco
 
     return _wrap

--- a/asyncworker/http/decorators.py
+++ b/asyncworker/http/decorators.py
@@ -1,5 +1,3 @@
-import typing
-
 from asyncworker.conf import logger
 from asyncworker.decorators import wraps
 from asyncworker.http.wrapper import RequestWrapper
@@ -8,6 +6,12 @@ from asyncworker.utils import get_handler_original_typehints
 
 
 def parse_path(handler):
+    """
+    Decorator que permite receber dinamicamente parametros do Request Path
+    Basta que o nome do parametro na assinatura do handler seja igual ao nome do parametro
+    declarado no Path HTTP.
+    """
+
     """
     Aqui usamos essa função `_dummy` apenas para aproveitar a implementação
     já existente em `typing.get_type_hints()`. 

--- a/asyncworker/http/decorators.py
+++ b/asyncworker/http/decorators.py
@@ -1,13 +1,28 @@
 import typing
-from asyncworker import wraps
 
 from asyncworker.conf import logger
+from asyncworker.decorators import wraps
 from asyncworker.http.wrapper import RequestWrapper
 from asyncworker.routes import call_http_handler
 
 
 def parse_path(handler):
-    handler_types_args = typing.get_type_hints(handler)
+    """
+    Aqui usamos essa função `_dummy` apenas para aproveitar a implementação
+    já existente em `typing.get_type_hints()`. 
+    Como essa implementação exige que passamos uma function, mas temos nesse momento
+    apenas um dict.
+    Então criamos essa função "vazia" e colocmos nela as anotações do handler
+    original.
+    """
+
+    def _dummy():
+        pass
+
+    _dummy.__annotations__ = getattr(
+        handler, "__original_annotations__", handler.__annotations__
+    )
+    handler_types_args = typing.get_type_hints(_dummy)
     handler_args_names = list(handler_types_args.keys())
 
     @wraps(handler)

--- a/asyncworker/http/decorators.py
+++ b/asyncworker/http/decorators.py
@@ -20,8 +20,9 @@ def parse_path(handler):
         pass
 
     _dummy.__annotations__ = getattr(
-        handler, "__original_annotations__", handler.__annotations__
+        handler, "asyncworker_original_annotations", handler.__annotations__
     )
+
     handler_types_args = typing.get_type_hints(_dummy)
     handler_args_names = list(handler_types_args.keys())
 

--- a/asyncworker/http/decorators.py
+++ b/asyncworker/http/decorators.py
@@ -4,6 +4,7 @@ from asyncworker.conf import logger
 from asyncworker.decorators import wraps
 from asyncworker.http.wrapper import RequestWrapper
 from asyncworker.routes import call_http_handler
+from asyncworker.utils import get_handler_original_typehints
 
 
 def parse_path(handler):
@@ -16,14 +17,7 @@ def parse_path(handler):
     original.
     """
 
-    def _dummy():
-        pass
-
-    _dummy.__annotations__ = getattr(
-        handler, "asyncworker_original_annotations", handler.__annotations__
-    )
-
-    handler_types_args = typing.get_type_hints(_dummy)
+    handler_types_args = get_handler_original_typehints(handler)
     handler_args_names = list(handler_types_args.keys())
 
     @wraps(handler)

--- a/asyncworker/http/decorators.py
+++ b/asyncworker/http/decorators.py
@@ -1,4 +1,5 @@
 import typing
+from asyncworker import wraps
 
 from asyncworker.conf import logger
 from asyncworker.http.wrapper import RequestWrapper
@@ -9,7 +10,8 @@ def parse_path(handler):
     handler_types_args = typing.get_type_hints(handler)
     handler_args_names = list(handler_types_args.keys())
 
-    async def _wrap(wrapper: RequestWrapper):
+    @wraps(handler)
+    async def _wrap(wrapper: RequestWrapper, **_):
         req = wrapper.http_request
 
         for param_name in handler_args_names:
@@ -31,4 +33,5 @@ def parse_path(handler):
 
         return await call_http_handler(wrapper, handler)
 
+    __import__("pdb").set_trace()
     return _wrap

--- a/asyncworker/http/decorators.py
+++ b/asyncworker/http/decorators.py
@@ -26,7 +26,7 @@ def parse_path(handler):
     handler_args_names = list(handler_types_args.keys())
 
     @wraps(handler)
-    async def _wrap(wrapper: RequestWrapper, **_):
+    async def _wrap(wrapper: RequestWrapper):
         req = wrapper.http_request
 
         for param_name in handler_args_names:

--- a/asyncworker/http/decorators.py
+++ b/asyncworker/http/decorators.py
@@ -33,5 +33,4 @@ def parse_path(handler):
 
         return await call_http_handler(wrapper, handler)
 
-    __import__("pdb").set_trace()
     return _wrap

--- a/asyncworker/types/resolver.py
+++ b/asyncworker/types/resolver.py
@@ -1,17 +1,7 @@
 import inspect
 import typing
 from asyncio import Task
-from typing import (
-    List,
-    Type,
-    Coroutine,
-    Dict,
-    Any,
-    Union,
-    Callable,
-    Iterable,
-    Tuple,
-)
+from typing import List, Type, Coroutine, Dict, Any, Union, Callable, Iterable
 
 from asyncworker.types.registry import TypesRegistry
 
@@ -45,6 +35,7 @@ class ArgResolver:
         return None
 
     async def _coro_executor(self, coro_ref: Callable[..., Coroutine]):
+        __import__("pdb").set_trace()
         params: Dict[str, Any] = {}
         unresolved_params = []
         coro_arguments = inspect.signature(coro_ref).parameters
@@ -63,8 +54,8 @@ class ArgResolver:
                     params[param_name] = param_value
                 else:
                     unresolved_params.append((param_name, param_type))
-            if unresolved_params:
-                raise TypeError(
-                    f"Unresolved params for coroutine {coro_ref}: {unresolved_params}"
-                )
+        #            if unresolved_params:
+        #                raise TypeError(
+        #                    f"Unresolved params for coroutine {coro_ref}: {unresolved_params}"
+        #                )
         return await coro_ref(**params)

--- a/asyncworker/types/resolver.py
+++ b/asyncworker/types/resolver.py
@@ -53,8 +53,8 @@ class ArgResolver:
                     params[param_name] = param_value
                 else:
                     unresolved_params.append((param_name, param_type))
-        #            if unresolved_params:
-        #                raise TypeError(
-        #                    f"Unresolved params for coroutine {coro_ref}: {unresolved_params}"
-        #                )
+            if unresolved_params:
+                raise TypeError(
+                    f"Unresolved params for coroutine {coro_ref}: {unresolved_params}"
+                )
         return await coro_ref(**params)

--- a/asyncworker/types/resolver.py
+++ b/asyncworker/types/resolver.py
@@ -1,7 +1,7 @@
 import inspect
 import typing
 from asyncio import Task
-from typing import List, Type, Coroutine, Dict, Any, Union, Callable, Iterable
+from typing import List, Type, Coroutine, Dict, Any, Union, Callable
 
 from asyncworker.types.registry import TypesRegistry
 
@@ -35,7 +35,6 @@ class ArgResolver:
         return None
 
     async def _coro_executor(self, coro_ref: Callable[..., Coroutine]):
-        __import__("pdb").set_trace()
         params: Dict[str, Any] = {}
         unresolved_params = []
         coro_arguments = inspect.signature(coro_ref).parameters

--- a/asyncworker/utils.py
+++ b/asyncworker/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import typing
 from functools import wraps
 from time import time as now
 from typing import Callable, Coroutine, Dict, Union, Optional
@@ -66,3 +67,35 @@ def entrypoint(f):
         return loop.run_until_complete(f(*args, **kwargs))
 
     return _
+
+
+def get_handler_original_typehints(handler):
+    """
+    Retorna a assinatura do handler asyncworker que está sendo decorado.
+    O retorno dessa chamada é equivalente a:
+    typing.get_type_hints(original_handler)
+    Onde `original_handler` é o handler asyncworker original.
+
+    Ideal para ser usado na pilha de decorators de um handler, ex:
+
+    .. code-block:: python
+
+        @deco1
+        @deco2
+        @deco3
+        async def handler(...):
+            pass
+
+    Nesse caso, se qualquer um dos 3 decorators precisar saber a assinatura
+    original, deve usar essa função passando a função recebida do decorator anterior.
+
+    """
+
+    def _dummy():
+        pass
+
+    _dummy.__annotations__ = getattr(
+        handler, "asyncworker_original_annotations", handler.__annotations__
+    )
+
+    return typing.get_type_hints(_dummy)

--- a/docs-src/changelog/v0.18.0.rst
+++ b/docs-src/changelog/v0.18.0.rst
@@ -1,0 +1,43 @@
+0.18.0
+================
+
+
+Data de release: não-publicada
+
+- Changelog: `0.18.0 <https://github.com/b2wdigital/async-worker/releases/tag/0.18.0>`_
+- Raw Commits: `0.18.0 <https://github.com/b2wdigital/async-worker/compare/0.17.0...0.18.0>`_
+
+
+Notas de atualização
+--------------------
+
+- Nessa versão mudamos a forma como decorators de handlers HTTP são escritos. Essa forma é **incompatível** com a forma anterior. A migração é simples e resolve também um conflito grave no uso de múltiplos decorators em um mesmo handler.
+
+Se antes você tinha um handler escrito dessa forma:
+
+.. code-block:: python
+
+  def my_handler_decorator(handler):
+      async def _wrapper(wrapper: RequestWrapper):
+          # Código principal do decorator vem aqui
+          return await call_http_handler(wrapper.http_request, handler)
+
+      return _wrapper
+
+Agora ele deve ser escrito dess forma:
+
+.. code-block:: python
+
+  from asyncowker.decorators import wraps
+
+  def my_handler_decorator(handler):
+      @wraps(handler)
+      async def _wrapper(wrapper: RequestWrapper):
+          # Código principal do decorator vem aqui
+          return await call_http_handler(wrapper.http_request, handler)
+
+      return _wrapper
+
+Repare que a migração envolve **apenas** adicionar um decorator :py:func:`asyncworker.decorators.wraps()` em volta da inner function retornada pelo seu decorator.
+
+Com essa modificação, agora é possivel ter múltiplos decorators que dependem da assinatura original (como é o casdo do :py:func:`asyncworker.http.decorators.parse_path()`) aplicados ao handler mesmo tempo.

--- a/docs-src/devguide/custom-decorators.rst
+++ b/docs-src/devguide/custom-decorators.rst
@@ -11,6 +11,7 @@ Aplicando decorators customizados a um handler HTTP
 - A inner function deve receber apenas :py:class:`asyncworker.http.wrapper.RequestWrapper`; Esse parametro **deve estar tipado**.
 - Essa inner function **deve ser** decorada com :py:func:`asyncworker.decorators.wraps()`.
 
+Importante: Não é necessário declarar seu decorator com `(*args, **kwargs)`. O asyncworker vai perceber o parametro que seu decorator precisa e chamará sempre passando apenas os parametros declarados na assinatura.
 
 Um exemplo simples de decorator:
 
@@ -38,3 +39,10 @@ Esse decorator poderia ser aplicado a um handler assim:
   @my_handler_decorator
   async def handler():
     return web.json_response({})
+
+
+Escrevendo um decorator que precisa conhece a assinatura original do handler
+============================================================================
+
+
+Caso o seu decorator precise saber a assinatura original do handler que está sendo decorado, ele pode ser descoberta acessando o atributo `asyncworker_original_annotations` da função que seu decorator está decorando. Essa funcão é o mesmo parametro que o `@wraps()` recebe.

--- a/docs-src/devguide/custom-decorators.rst
+++ b/docs-src/devguide/custom-decorators.rst
@@ -45,4 +45,30 @@ Escrevendo um decorator que precisa conhece a assinatura original do handler
 ============================================================================
 
 
-Caso o seu decorator precise saber a assinatura original do handler que está sendo decorado, ele pode ser descoberta acessando o atributo `asyncworker_original_annotations` da função que seu decorator está decorando. Essa funcão é o mesmo parametro que o `@wraps()` recebe.
+Caso o seu decorator precise saber a assinatura original do handler que está sendo decorado, ela pode ser descoberta usando :py:func:`asyncworker.utils.get_handler_original_typehints()`. Essa função deve receber o mesmo parmetro que o ``@wraps()`` recebe. O retorno dessa chamada é o dicionário original que estava no atributo ``__annotations__`` do handler original.
+
+Um exemplo:
+
+.. code-block:: python
+
+    def simple_deco(handler):
+        @wraps(handler)
+        async def _wrapper():
+            return await handler()
+
+        return _wrapper
+
+    def other_deco(handler):
+        @wraps(handler)
+        async def _wrap():
+            return get_handler_original_typehints(handler)
+
+        return _wrap
+
+    @other_deco
+    @simple_deco
+    async def handler(a: bool, s: str):
+          pass
+
+
+Nesse caso, mesmo o decorator ``@other_deco()`` sendo o decorator no topo da lista de decorators, ele é capaz de retornar a assinatura original.

--- a/docs-src/devguide/custom-decorators.rst
+++ b/docs-src/devguide/custom-decorators.rst
@@ -3,13 +3,13 @@
 Aplicando decorators customizados a um handler HTTP
 =====================================================
 
-É possível escrever seus próprios decorators e aplicá-los a seus handlers, junto com o decorator ``@app.route``. No entando temos algumas regras:
+É possível escrever seus próprios decorators e aplicá-los a seus handlers, junto com os decorators ``@app.http.*``. No entando temos algumas regras:
 
-- O decorator ``@app.route()`` deve estar sempre no topo da lista de decorators de um handler;
+- O decorator ``@app.http.*()`` deve estar sempre no topo da lista de decorators de um handler;
 - Os decorators intermediários devem sempre usar a função :py:func:`asyncworker.routes.call_http_handler()` no momento de chamar o objeto que estão decorando;
 - A inner function retornada pelo decorator deve ser uma corotina;
-- A inner function deve receber apenas :py:class:`asyncworker.http.wrapper.RequestWrapper`;
-- Essa inner function não deve ser decorada com ``@functools.wraps()``.
+- A inner function deve receber apenas :py:class:`asyncworker.http.wrapper.RequestWrapper`; Esse parametro **deve estar tipado**.
+- Essa inner function **deve ser** decorada com :py:func:`asyncworker.decorators.wraps()`.
 
 
 Um exemplo simples de decorator:
@@ -17,8 +17,10 @@ Um exemplo simples de decorator:
 .. code:: python
 
   from asyncworker.http.wrapper import RequestWrapper
+  from asyncworker.decorators import wraps
 
   def my_handler_decorator(handler):
+      @wraps(handler)
       async def _wrapper(wrapper: RequestWrapper):
           # Código principal do decorator vem aqui
           return await call_http_handler(wrapper.http_request, handler)
@@ -32,7 +34,7 @@ Esse decorator poderia ser aplicado a um handler assim:
 
 .. code:: python
 
-  @app.route(["/"], type=RouteTypes.HTTP, methods=["GET"])
+  @app.http.get(["/"])
   @my_handler_decorator
   async def handler():
     return web.json_response({})

--- a/tests/http/test_http_decorators.py
+++ b/tests/http/test_http_decorators.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from typing import List
 
 from aiohttp import web
 from asynctest import mock, TestCase

--- a/tests/http/test_http_decorators.py
+++ b/tests/http/test_http_decorators.py
@@ -70,7 +70,7 @@ class HTTPDecoratorsTest(TestCase):
 
         def other_deco(handler):
             @wraps(handler)
-            async def _h(req: RequestWrapper, **_):
+            async def _h(req: RequestWrapper):
                 return await call_http_handler(req, handler)
 
             return _h
@@ -129,13 +129,13 @@ class HTTPDecoratorsTest(TestCase):
 
     async def test_can_have_a_param_with_same_name_of_handler(self):
         """
-        Valida que os decorators pelo caminho podem receber parametros 
-        que possuem o mesmo nome de parametros do handler original, e isso 
+        Valida que os decorators pelo caminho podem receber parametros
+        que possuem o mesmo nome de parametros do handler original, e isso
         não interfere na chamada do handler.
 
         def deco_1(handler):
             @wraps(handler)
-            async def wrap(r: RequestWrapper, **_):
+            async def wrap(r: RequestWrapper):
                 return await call_http_handler(r, handler)
 
             return wrap

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,8 @@
 from asynctest import TestCase
 
 from asyncworker.decorators import wraps
+from asyncworker.types.registry import TypesRegistry
+from asyncworker.types.resolver import ArgResolver
 
 
 def handler_register(func):
@@ -35,6 +37,10 @@ def _deco3(handler):
 
 
 class TestWrapsDecorator(TestCase):
+    async def setUp(self):
+        self.registry = TypesRegistry()
+        self.resolver = ArgResolver(registry=self.registry)
+
     async def test_with_one_first_decorator(self):
         @handler_register
         @_deco
@@ -101,10 +107,84 @@ class TestWrapsDecorator(TestCase):
         )
 
     async def test_call_chain_one_decorator(self):
-        self.fail()
+        registry = TypesRegistry()
+        resolver = ArgResolver(registry=registry)
+
+        def deco_final(_handler):
+            @wraps(_handler)
+            async def _wrap(p: str):
+                registry.set(False)
+                return await resolver.wrap(_handler)
+
+            return _wrap
+
+        def _handler_deco(handler):
+            @wraps(handler)
+            async def _handler_deco_wrap(x: bool):
+                registry.set(42)
+                registry.set(True)
+                return await resolver.wrap(handler)
+
+            return _handler_deco_wrap
+
+        @deco_final
+        @_handler_deco
+        async def handler(p: int, flag: bool):
+            return (p, flag)
+
+        registry.set("is p")
+        result = await resolver.wrap(handler)
+        self.assertEqual((42, True), result)
 
     async def test_call_chain_two_decorators(self):
-        self.fail()
+        """
+        Cada decorator fornece (acumula) um dos parametros necessários 
+        para o handler ser chamado
+        """
 
-    async def test_call_chain_three_decorators(self):
-        self.fail()
+        registry = self.registry
+        resolver = self.resolver
+
+        def deco_final(handler):
+            """
+            Inicia o call chain
+            """
+
+            @wraps(handler)
+            async def wrap():
+                return await resolver.wrap(handler)
+
+            return wrap
+
+        def deco1(handler):
+            """
+            Fornece o bool
+            """
+
+            @wraps(handler)
+            async def wrap():
+                registry.set(True)
+                return await resolver.wrap(handler)
+
+            return wrap
+
+        def deco2(handler):
+            """
+            Fornecce a str
+            """
+
+            @wraps(handler)
+            async def wrap():
+                registry.set("String")
+                return await resolver.wrap(handler)
+
+            return wrap
+
+        @deco_final
+        @deco1
+        @deco2
+        async def handler(b: bool, c: str):
+            return (b, c)
+
+        result = await self.resolver.wrap(handler)
+        self.assertEqual((True, "String"), result)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -3,6 +3,7 @@ from asynctest import TestCase
 from asyncworker.decorators import wraps
 from asyncworker.types.registry import TypesRegistry
 from asyncworker.types.resolver import ArgResolver
+from asyncworker.utils import get_handler_original_typehints
 
 
 def handler_register(func):
@@ -50,7 +51,7 @@ class TestWrapsDecorator(TestCase):
         final_func = await _func()
         self.assertEqual(final_func.__annotations__, {"s": str})
         self.assertEqual(
-            final_func.asyncworker_original_annotations, {"q": int, "b": bool}
+            get_handler_original_typehints(final_func), {"q": int, "b": bool}
         )
 
     async def test_with_two_second_decorators(self):
@@ -63,7 +64,7 @@ class TestWrapsDecorator(TestCase):
         final_func = await _func()
         self.assertEqual(final_func.__annotations__, {"param": bool, "i": int})
         self.assertEqual(
-            final_func.asyncworker_original_annotations,
+            get_handler_original_typehints(final_func),
             {"other": int, "integer": int, "feature": bool},
         )
 
@@ -80,7 +81,7 @@ class TestWrapsDecorator(TestCase):
             final_func.__annotations__, {"flag": bool, "other": str}
         )
         self.assertEqual(
-            final_func.asyncworker_original_annotations,
+            get_handler_original_typehints(final_func),
             {"other": int, "integer": int, "feature": bool},
         )
 
@@ -103,7 +104,7 @@ class TestWrapsDecorator(TestCase):
         final_func = await _func()
         self.assertEqual(final_func.__annotations__, {"param": bool})
         self.assertEqual(
-            final_func.asyncworker_original_annotations, {"x": bool, "y": int}
+            get_handler_original_typehints(final_func), {"x": bool, "y": int}
         )
 
     async def test_call_chain_one_decorator(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -50,7 +50,7 @@ class TestWrapsDecorator(TestCase):
         final_func = await _func()
         self.assertEqual(final_func.__annotations__, {"s": str})
         self.assertEqual(
-            final_func.__original_annotations__, {"q": int, "b": bool}
+            final_func.asyncworker_original_annotations, {"q": int, "b": bool}
         )
 
     async def test_with_two_second_decorators(self):
@@ -63,7 +63,7 @@ class TestWrapsDecorator(TestCase):
         final_func = await _func()
         self.assertEqual(final_func.__annotations__, {"param": bool, "i": int})
         self.assertEqual(
-            final_func.__original_annotations__,
+            final_func.asyncworker_original_annotations,
             {"other": int, "integer": int, "feature": bool},
         )
 
@@ -80,7 +80,7 @@ class TestWrapsDecorator(TestCase):
             final_func.__annotations__, {"flag": bool, "other": str}
         )
         self.assertEqual(
-            final_func.__original_annotations__,
+            final_func.asyncworker_original_annotations,
             {"other": int, "integer": int, "feature": bool},
         )
 
@@ -103,7 +103,7 @@ class TestWrapsDecorator(TestCase):
         final_func = await _func()
         self.assertEqual(final_func.__annotations__, {"param": bool})
         self.assertEqual(
-            final_func.__original_annotations__, {"x": bool, "y": int}
+            final_func.asyncworker_original_annotations, {"x": bool, "y": int}
         )
 
     async def test_call_chain_one_decorator(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,110 @@
+from asynctest import TestCase
+
+from asyncworker.decorators import wraps
+
+
+def handler_register(func):
+    async def _register_wrap(x: int = 0):
+        return func
+
+    return _register_wrap
+
+
+def _deco(handler):
+    @wraps(handler)
+    async def _wrapper(s: str, **_):
+        pass
+
+    return _wrapper
+
+
+def _deco2(handler):
+    @wraps(handler)
+    async def _wrapper(param: bool, i: int, **_):
+        pass
+
+    return _wrapper
+
+
+def _deco3(handler):
+    @wraps(handler)
+    async def _wrapper(other: str, flag: bool, **_):
+        pass
+
+    return _wrapper
+
+
+class TestWrapsDecorator(TestCase):
+    async def test_with_one_first_decorator(self):
+        @handler_register
+        @_deco
+        async def _func(q: int, b: bool):
+            pass
+
+        final_func = await _func()
+        self.assertEqual(final_func.__annotations__, {"s": str})
+        self.assertEqual(
+            final_func.__original_annotations__, {"q": int, "b": bool}
+        )
+
+    async def test_with_two_second_decorators(self):
+        @handler_register
+        @_deco2
+        @_deco
+        async def _func(other: int, integer: int, feature: bool):
+            pass
+
+        final_func = await _func()
+        self.assertEqual(final_func.__annotations__, {"param": bool, "i": int})
+        self.assertEqual(
+            final_func.__original_annotations__,
+            {"other": int, "integer": int, "feature": bool},
+        )
+
+    async def test_with_three_decorators(self):
+        @handler_register
+        @_deco3
+        @_deco2
+        @_deco
+        async def _func(other: int, integer: int, feature: bool):
+            pass
+
+        final_func = await _func()
+        self.assertEqual(
+            final_func.__annotations__, {"flag": bool, "other": str}
+        )
+        self.assertEqual(
+            final_func.__original_annotations__,
+            {"other": int, "integer": int, "feature": bool},
+        )
+
+    async def test_when_decorator_has_parameters(self):
+        def _deco_with_params(a: int):
+            def _wrap1(handler):
+                @wraps(handler)
+                async def _final_wrap(param: bool, **_):
+                    pass
+
+                return _final_wrap
+
+            return _wrap1
+
+        @handler_register
+        @_deco_with_params(42)
+        async def _func(x: bool, y: int):
+            pass
+
+        final_func = await _func()
+        self.assertEqual(final_func.__annotations__, {"param": bool})
+        self.assertEqual(
+            final_func.__original_annotations__, {"x": bool, "y": int}
+        )
+
+    async def test_call_chain_one_decorator(self):
+        self.fail()
+
+    async def test_call_chain_two_decorators(self):
+        self.fail()
+
+    async def test_call_chain_three_decorators(self):
+        self.fail()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -14,7 +14,7 @@ def handler_register(func):
 
 def _deco(handler):
     @wraps(handler)
-    async def _wrapper(s: str, **_):
+    async def _wrapper(s: str):
         pass
 
     return _wrapper
@@ -22,7 +22,7 @@ def _deco(handler):
 
 def _deco2(handler):
     @wraps(handler)
-    async def _wrapper(param: bool, i: int, **_):
+    async def _wrapper(param: bool, i: int):
         pass
 
     return _wrapper
@@ -30,7 +30,7 @@ def _deco2(handler):
 
 def _deco3(handler):
     @wraps(handler)
-    async def _wrapper(other: str, flag: bool, **_):
+    async def _wrapper(other: str, flag: bool):
         pass
 
     return _wrapper
@@ -88,7 +88,7 @@ class TestWrapsDecorator(TestCase):
         def _deco_with_params(a: int):
             def _wrap1(handler):
                 @wraps(handler)
-                async def _final_wrap(param: bool, **_):
+                async def _final_wrap(param: bool):
                     pass
 
                 return _final_wrap

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ class TimeitTests(asynctest.TestCase):
     async def test_it_marks_starting_times(self):
         coro = asynctest.CoroutineMock()
         async with Timeit(name="Xablau", callback=coro) as timeit:
-            self.assertEqual(timeit.start, 1_149_573_966.0)
+            self.assertEqual(timeit.start, 1_149_573_966.1)
 
     @freeze_time("2006-06-06 06:06:07")
     async def test_it_marks_finishing_times(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ class TimeitTests(asynctest.TestCase):
     async def test_it_marks_starting_times(self):
         coro = asynctest.CoroutineMock()
         async with Timeit(name="Xablau", callback=coro) as timeit:
-            self.assertEqual(timeit.start, 1_149_573_966.1)
+            self.assertEqual(timeit.start, 1_149_573_966.0)
 
     @freeze_time("2006-06-06 06:06:07")
     async def test_it_marks_finishing_times(self):


### PR DESCRIPTION
Esse PR muda a forma como um decorator para um handler deve ser escrito. A forma anterior impedia que dois decorators (que dependessem da assinatura original do handler) fossem aplicados a um mesmo handler. Um exemplo:

O decorator `@parse_path` precisa conhecer o handler **original** para que possa extrair corretamente os valores do request a passar para o `TypesRegistry`. Isso significava que esse decorator deveria ficar **sempre** imediatamente acima do handler que estava sendo decorado.

O problema isso é que a partir do momento que você precisa decorar seu handler com quaisquer outros decorators você teria que lembrar dessa regra, ou seja, sempre deixar o `@parse_path` mais perto do handler.

Isso piorava quando você tinha dois decorators que precisavam conhecer a assinatura original. Essa configuração era simplesmente impossível de ser feita. Algo simples como:

```python

@app.http.get(["/by_id/{_id}/other/{value}"])
@parse_path
@meu_decorator
async def by_id(_id: int, value: int):
    return web.json_response({"url-param-value": f"{_id}, {value}"})

``` 

A implementação desse PR não só corrige esse problema como prepara o terreno para que a implementação abaixo possa funcionar:

```python
from asyncworker.decorators import wraps

def _deco(handler):
    @wraps(handler)
    async def _wrap(r: RequestWrapper):
        r.types_registry.set(42, type_definition=int)
        return await call_http_handler(r, handler)

    return _wrap

@self.app.http.get(["/path/{n}"])
@_deco
async def _path(n: PathParam[int], p: int):
    return json_response({"n": n.unpack(), "p": p})
```

O que está acontecendo aqui é que um decorator intermediário fornece o valor do parametro `p` e o asyncworker, nativamente, consegue perceber que o handler original recebe um parametro do path chamado `n`, inteiro e consegue extrair o valor desse parametro e passá-lo no momento de chamar o handler.

Tudo isso mesmo o handler estando decorado por mais de um decorator.

Mais sobre a possibilidade de um handler receber parametros "mais ricos" do que apenas request: #114. Uma primeira issue para implementar a extração de parametros do path está no #136.


# Tarefas
- [x] Mudar a docstring do `@parse_path`. Escrever uma docstring correta e deixar o comentário atual apenas como comentário mesmo.
- [x] simplificar a implentação do `@wraps`. Da pra fazer um `getattr()` com default value. Da pra substituir todo aquele `if/else`
- [x] Pensar em uma interface para que quem estiver escrevendo um decorator possa ter acesso à assinatura original do handler, em vez de ter que acessar diretamente o atributo que o `@wraps()` cria. Se não conseguirmos pensar em algo agora, tudo bem deixar assim.
- [x] Remover todos os `**_` dos códigos dos decorators intermediários.
- [x] Documentar que não é necessário adicionar `*args, **kwargs` nos decorators.