### PR TITLE
Implementação do typehint PathParam[T]

### DIFF
--- a/asyncworker/decorators.py
+++ b/asyncworker/decorators.py
@@ -19,6 +19,11 @@ def wraps(original_handler):
             "asyncworker_original_annotations",
             original_handler.__annotations__,
         )
+        deco.asyncworker_original_qualname = getattr(
+            original_handler,
+            "asyncworker_original_qualname",
+            original_handler.__qualname__,
+        )
         return deco
 
     return _wrap

--- a/asyncworker/http/decorators.py
+++ b/asyncworker/http/decorators.py
@@ -2,7 +2,7 @@ from asyncworker.conf import logger
 from asyncworker.decorators import wraps
 from asyncworker.http.wrapper import RequestWrapper
 from asyncworker.routes import call_http_handler
-from asyncworker.utils import get_handler_original_typehints
+from asyncworker.typing import get_handler_original_typehints
 
 
 def parse_path(handler):

--- a/asyncworker/http/entrypoints.py
+++ b/asyncworker/http/entrypoints.py
@@ -5,8 +5,11 @@ from asyncworker.http import HTTPMethods
 from asyncworker.http.types import PathParam
 from asyncworker.http.wrapper import RequestWrapper
 from asyncworker.routes import RoutesRegistry, HTTPRoute, call_http_handler
-from asyncworker.typing import get_origin, get_args
-from asyncworker.utils import get_handler_original_typehints
+from asyncworker.typing import (
+    get_origin,
+    get_args,
+    get_handler_original_typehints,
+)
 
 
 class PathParamSpec:

--- a/asyncworker/http/entrypoints.py
+++ b/asyncworker/http/entrypoints.py
@@ -1,8 +1,37 @@
-from typing import Callable, List
+from typing import Callable, List, Type, get_type_hints
 
 from asyncworker.entrypoints import _extract_async_callable, EntrypointInterface
 from asyncworker.http import HTTPMethods
-from asyncworker.routes import RoutesRegistry, HTTPRoute
+from asyncworker.http.types import PathParam
+from asyncworker.http.wrapper import RequestWrapper
+from asyncworker.routes import RoutesRegistry, HTTPRoute, call_http_handler
+from asyncworker.typing import get_origin, get_args
+from asyncworker.utils import get_handler_original_typehints
+
+
+class PathParamSpec:
+    def __init__(self, name, base: Type):
+        self.name = name
+        self.base = base
+
+
+def _parse_path(f):
+    handler_type_hints = get_handler_original_typehints(f)
+    path_params = [
+        PathParamSpec(name=name, base=_type)
+        for name, _type in handler_type_hints.items()
+        if get_origin(handler_type_hints[name]) is PathParam
+    ]
+
+    async def _wrap(wrapper: RequestWrapper):
+        for p in path_params:
+            typed_val = await p.base.from_request(
+                request=wrapper, arg_name=p.name, arg_type=get_args(p.base)[0]
+            )
+            wrapper.types_registry.set(typed_val, p.base, param_name=p.name)
+        return await call_http_handler(wrapper, f)
+
+    return _wrap
 
 
 def _register_http_handler(
@@ -11,7 +40,11 @@ def _register_http_handler(
     def _wrap(f):
 
         cb = _extract_async_callable(f)
-        route = HTTPRoute(handler=cb, routes=routes, methods=[method])
+
+        cb_with_parse_path = _parse_path(cb)
+        route = HTTPRoute(
+            handler=cb_with_parse_path, routes=routes, methods=[method]
+        )
         registry.add_http_route(route)
 
         return f

--- a/asyncworker/http/entrypoints.py
+++ b/asyncworker/http/entrypoints.py
@@ -1,5 +1,6 @@
 from typing import Callable, List, Type
 
+from asyncworker.decorators import wraps
 from asyncworker.entrypoints import _extract_async_callable, EntrypointInterface
 from asyncworker.http import HTTPMethods
 from asyncworker.http.types import PathParam
@@ -38,6 +39,7 @@ def _install_request_parser_annotation(f, base_generic_type: Type):
                     )
                 )
 
+    @wraps(f)
     async def _wrap(wrapper: RequestWrapper):
         for p in path_params:
             typed_val = await p.base.from_request(

--- a/asyncworker/http/entrypoints.py
+++ b/asyncworker/http/entrypoints.py
@@ -20,7 +20,7 @@ class RequestParserAnnotationSpec:
         self.arg_type = arg_type
 
 
-def _parse_path(f, base_generic_type: Type):
+def _install_request_parser_annotation(f, base_generic_type: Type):
     handler_type_hints = get_handler_original_typehints(f)
     path_params: List[RequestParserAnnotationSpec] = []
 
@@ -56,7 +56,7 @@ def _register_http_handler(
 
         cb = _extract_async_callable(f)
 
-        cb_with_parse_path = _parse_path(cb, PathParam)
+        cb_with_parse_path = _install_request_parser_annotation(cb, PathParam)
         route = HTTPRoute(
             handler=cb_with_parse_path, routes=routes, methods=[method]
         )

--- a/asyncworker/http/types.py
+++ b/asyncworker/http/types.py
@@ -18,7 +18,7 @@ class RequestParser(Generic[T]):
         raise NotADirectoryError()
 
     @abstractmethod
-    def unpack(self) -> T:
+    async def unpack(self) -> T:
         raise NotImplementedError()
 
 
@@ -30,5 +30,5 @@ class PathParam(RequestParser[T]):
         val = request.http_request.match_info[arg_name]
         return cls(arg_type(val))
 
-    def unpack(self) -> T:
+    async def unpack(self) -> T:
         return self._value

--- a/asyncworker/http/types.py
+++ b/asyncworker/http/types.py
@@ -1,6 +1,8 @@
 from abc import abstractmethod
 from typing import Generic, TypeVar, Type
 
+from aiohttp.web import HTTPBadRequest
+
 from asyncworker.http.wrapper import RequestWrapper
 
 T = TypeVar("T")
@@ -27,4 +29,7 @@ class PathParam(RequestParser[T]):
         cls, request: RequestWrapper, arg_name: str, arg_type: Type
     ) -> "PathParam[T]":
         val = request.http_request.match_info[arg_name]
-        return cls(arg_type(val))
+        try:
+            return cls(arg_type(val))
+        except ValueError as ve:
+            raise HTTPBadRequest(reason=ve.args[0])

--- a/asyncworker/http/types.py
+++ b/asyncworker/http/types.py
@@ -15,7 +15,7 @@ class RequestParser(Generic[T]):
     async def from_request(
         cls, request: RequestWrapper, arg_name: str, arg_type: Type
     ) -> "RequestParser[T]":
-        raise NotADirectoryError()
+        raise NotImplementedError()
 
     @abstractmethod
     async def unpack(self) -> T:

--- a/asyncworker/http/types.py
+++ b/asyncworker/http/types.py
@@ -1,8 +1,6 @@
 from abc import abstractmethod
 from typing import Generic, TypeVar, Type
 
-from aiohttp.web import HTTPBadRequest
-
 from asyncworker.http.wrapper import RequestWrapper
 
 T = TypeVar("T")
@@ -29,7 +27,4 @@ class PathParam(RequestParser[T]):
         cls, request: RequestWrapper, arg_name: str, arg_type: Type
     ) -> "PathParam[T]":
         val = request.http_request.match_info[arg_name]
-        try:
-            return cls(arg_type(val))
-        except ValueError as ve:
-            raise HTTPBadRequest(reason=ve.args[0])
+        return cls(arg_type(val))

--- a/asyncworker/http/types.py
+++ b/asyncworker/http/types.py
@@ -1,0 +1,20 @@
+from typing import Generic, TypeVar, Type
+
+from asyncworker.http.wrapper import RequestWrapper
+
+T = TypeVar("T")
+
+
+class PathParam(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self._value: T = value
+
+    @classmethod
+    async def from_request(
+        cls, request: RequestWrapper, arg_name: str, arg_type: Type
+    ) -> "PathParam":
+        val = request.http_request.match_info[arg_name]
+        return cls(arg_type(val))
+
+    def unpack(self) -> T:
+        return self._value

--- a/asyncworker/http/types.py
+++ b/asyncworker/http/types.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Generic, TypeVar, Type
 
 from asyncworker.http.wrapper import RequestWrapper
@@ -5,14 +6,27 @@ from asyncworker.http.wrapper import RequestWrapper
 T = TypeVar("T")
 
 
-class PathParam(Generic[T]):
+class RequestParser(Generic[T]):
     def __init__(self, value: T) -> None:
         self._value: T = value
 
     @classmethod
+    @abstractmethod
     async def from_request(
         cls, request: RequestWrapper, arg_name: str, arg_type: Type
-    ) -> "PathParam":
+    ) -> "RequestParser[T]":
+        raise NotADirectoryError()
+
+    @abstractmethod
+    def unpack(self) -> T:
+        raise NotImplementedError()
+
+
+class PathParam(RequestParser[T]):
+    @classmethod
+    async def from_request(
+        cls, request: RequestWrapper, arg_name: str, arg_type: Type
+    ) -> "PathParam[T]":
         val = request.http_request.match_info[arg_name]
         return cls(arg_type(val))
 

--- a/asyncworker/http/types.py
+++ b/asyncworker/http/types.py
@@ -17,9 +17,8 @@ class RequestParser(Generic[T]):
     ) -> "RequestParser[T]":
         raise NotImplementedError()
 
-    @abstractmethod
     async def unpack(self) -> T:
-        raise NotImplementedError()
+        return self._value
 
 
 class PathParam(RequestParser[T]):
@@ -29,6 +28,3 @@ class PathParam(RequestParser[T]):
     ) -> "PathParam[T]":
         val = request.http_request.match_info[arg_name]
         return cls(arg_type(val))
-
-    async def unpack(self) -> T:
-        return self._value

--- a/asyncworker/types/registry.py
+++ b/asyncworker/types/registry.py
@@ -13,7 +13,7 @@ class RegistryItem:
 class TypesRegistry:
     def __init__(self):
         self._data: Dict[Tuple, RegistryItem] = {}
-        self.__by_name: Dict[str, RegistryItem] = {}
+        self._by_name: Dict[str, RegistryItem] = {}
 
     def set(
         self,
@@ -24,22 +24,25 @@ class TypesRegistry:
         has_type_args = get_args(type_definition)
         origin = get_origin(obj) or obj.__class__
 
-        self._data[(origin, has_type_args)] = RegistryItem(
+        registry_item = RegistryItem(
             type=origin, value=obj, type_args=has_type_args
         )
+
+        self._data[(origin, has_type_args)] = registry_item
+
         if param_name:
-            self.__by_name[param_name] = RegistryItem(
-                type=obj.__class__, value=obj
-            )
+            self._by_name[param_name] = registry_item
 
     def get(
         self, _type: Type, param_name: str = None, type_args=None
     ) -> Optional[Any]:
         origin = get_origin(_type) or _type
+        _type_args = type_args or get_args(_type)
         if param_name:
             try:
-                if self.__by_name[param_name].type == _type:
-                    return self.__by_name[param_name].value
+                item = self._by_name[param_name]
+                if (item.type, item.type_args) == (origin, _type_args):
+                    return item.value
             except KeyError:
                 return None
 

--- a/asyncworker/typing/__init__.py
+++ b/asyncworker/typing/__init__.py
@@ -1,0 +1,15 @@
+from typing import Optional, Tuple, Any, Type
+
+
+def get_args(_type: Type) -> Optional[Tuple]:
+    if _type and hasattr(_type, "__args__"):
+        return _type.__args__
+
+    return None
+
+
+def get_origin(_type: Type) -> Optional[Type]:
+    if _type and hasattr(_type, "__origin__"):
+        return _type.__origin__
+
+    return None

--- a/asyncworker/typing/__init__.py
+++ b/asyncworker/typing/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Type
+from typing import Optional, Tuple, Type, get_type_hints
 
 
 def get_args(_type: Type) -> Optional[Tuple]:
@@ -13,3 +13,35 @@ def get_origin(_type: Type) -> Optional[Type]:
         return _type.__origin__
 
     return None
+
+
+def get_handler_original_typehints(handler):
+    """
+    Retorna a assinatura do handler asyncworker que está sendo decorado.
+    O retorno dessa chamada é equivalente a:
+    typing.get_type_hints(original_handler)
+    Onde `original_handler` é o handler asyncworker original.
+
+    Ideal para ser usado na pilha de decorators de um handler, ex:
+
+    .. code-block:: python
+
+        @deco1
+        @deco2
+        @deco3
+        async def handler(...):
+            pass
+
+    Nesse caso, se qualquer um dos 3 decorators precisar saber a assinatura
+    original, deve usar essa função passando a função recebida do decorator anterior.
+
+    """
+
+    def _dummy():
+        pass
+
+    _dummy.__annotations__ = getattr(
+        handler, "asyncworker_original_annotations", handler.__annotations__
+    )
+
+    return get_type_hints(_dummy)

--- a/asyncworker/typing/__init__.py
+++ b/asyncworker/typing/__init__.py
@@ -45,3 +45,13 @@ def get_handler_original_typehints(handler):
     )
 
     return get_type_hints(_dummy)
+
+
+def is_base_type(_type, base_type):
+    """
+    Retorna True para argumentos de um tipo base `base_type`.
+    Ex:
+    (a: MyGeneric[int]) -> True
+    (b: MyGeneric) -> True
+    """
+    return get_origin(_type) is base_type or issubclass(_type, base_type)

--- a/asyncworker/typing/__init__.py
+++ b/asyncworker/typing/__init__.py
@@ -1,14 +1,14 @@
 from typing import Optional, Tuple, Type, get_type_hints
 
 
-def get_args(_type: Type) -> Optional[Tuple]:
+def get_args(_type: Optional[Type]) -> Optional[Tuple]:
     if _type and hasattr(_type, "__args__"):
         return _type.__args__
 
     return None
 
 
-def get_origin(_type: Type) -> Optional[Type]:
+def get_origin(_type: Optional[Type]) -> Optional[Type]:
     if _type and hasattr(_type, "__origin__"):
         return _type.__origin__
 

--- a/asyncworker/typing/__init__.py
+++ b/asyncworker/typing/__init__.py
@@ -55,3 +55,9 @@ def is_base_type(_type, base_type):
     (b: MyGeneric) -> True
     """
     return get_origin(_type) is base_type or issubclass(_type, base_type)
+
+
+def get_handler_original_qualname(handler):
+    return getattr(
+        handler, "asyncworker_original_qualname", handler.__qualname__
+    )

--- a/asyncworker/typing/__init__.py
+++ b/asyncworker/typing/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Any, Type
+from typing import Optional, Tuple, Type
 
 
 def get_args(_type: Type) -> Optional[Tuple]:

--- a/asyncworker/typing/__init__.py
+++ b/asyncworker/typing/__init__.py
@@ -56,11 +56,8 @@ def is_base_type(_type, base_type):
     """
     if get_origin(_type) is base_type:
         return True
-    else:
-        try:
-            return issubclass(_type, base_type)
-        except TypeError:
-            return False
+
+    return issubclass(_type, base_type)
 
 
 def get_handler_original_qualname(handler):

--- a/asyncworker/typing/__init__.py
+++ b/asyncworker/typing/__init__.py
@@ -54,7 +54,13 @@ def is_base_type(_type, base_type):
     (a: MyGeneric[int]) -> True
     (b: MyGeneric) -> True
     """
-    return get_origin(_type) is base_type or issubclass(_type, base_type)
+    if get_origin(_type) is base_type:
+        return True
+    else:
+        try:
+            return issubclass(_type, base_type)
+        except TypeError:
+            return False
 
 
 def get_handler_original_qualname(handler):

--- a/asyncworker/utils.py
+++ b/asyncworker/utils.py
@@ -67,35 +67,3 @@ def entrypoint(f):
         return loop.run_until_complete(f(*args, **kwargs))
 
     return _
-
-
-def get_handler_original_typehints(handler):
-    """
-    Retorna a assinatura do handler asyncworker que está sendo decorado.
-    O retorno dessa chamada é equivalente a:
-    typing.get_type_hints(original_handler)
-    Onde `original_handler` é o handler asyncworker original.
-
-    Ideal para ser usado na pilha de decorators de um handler, ex:
-
-    .. code-block:: python
-
-        @deco1
-        @deco2
-        @deco3
-        async def handler(...):
-            pass
-
-    Nesse caso, se qualquer um dos 3 decorators precisar saber a assinatura
-    original, deve usar essa função passando a função recebida do decorator anterior.
-
-    """
-
-    def _dummy():
-        pass
-
-    _dummy.__annotations__ = getattr(
-        handler, "asyncworker_original_annotations", handler.__annotations__
-    )
-
-    return typing.get_type_hints(_dummy)

--- a/docs-src/changelog/v0.19.1.rst
+++ b/docs-src/changelog/v0.19.1.rst
@@ -1,0 +1,15 @@
+0.19.1
+================
+
+
+Data de release: não lançada
+
+Tag: `0.19.1 <https://github.com/b2wdigital/async-worker/releases/tag/0.19.1>`_
+
+Raw Commits: `0.19.1 <https://github.com/b2wdigital/async-worker/compare/0.19.0...0.19.1>`_
+
+
+Notas de atualização
+--------------------
+
+Nessa versão depreciamos o uso do decorator ``@parse_path``. A forma correta de receber parametros do path do request é usando o typehint :ref:`PathParam[T] <handler-path-param>`.

--- a/docs-src/userguide/handlers/http/doc.rst
+++ b/docs-src/userguide/handlers/http/doc.rst
@@ -211,3 +211,5 @@ Nesse caso, como handler está dizendo que precisa de um parametro chamado ``_id
 Para que seja possível lidar bem com linters (tipo ``mypy``) o que o asyncworker faz é de fato chamar o handler passando uma instância de ``PathParam``. Essa intância tem, internamente, o valor real que foi passdo no path do request, já convertido para o tipo correto. Nesse caso aqui um ``int``.
 
 Importante notar que só serão passados ao handler os parametros que estão definidos na assinatura. Então se seu path recebe dois parametros e seu handler só se interessa por um deles, basta declarar na assinatura do handler o parametro que você quer receber.
+
+Esse typehint pode receber qualquer tipo primitvo do python: ``int``, ``float``, ``bool``. Quando recebe ``bool`` valem as regras do `Pydantic <https://pydantic-docs.helpmanual.io/usage/types/#booleans>`_.

--- a/docs-src/userguide/handlers/http/doc.rst
+++ b/docs-src/userguide/handlers/http/doc.rst
@@ -164,34 +164,50 @@ Um exemplo de como popular esse registry é através de um decorator aplicado di
 
 Aqui o decorator ``auth_required()`` é responsável por fazer a autenticação, pegando dados do Request e encontrando um usuário válido. Se um usuário não puder ser encontrado, retorna ``HTTPStatus.UNAUTHORIZED``. Se um usuário autenticar com sucesso, apenas adiciona o objeto user (que é do tipo ``User``) no registry que está no ``RequestWrapper``. Isso é o suficiente para que o handler, quando for chamado, receba diretamente esse user já autenticado.
 
+Typehints que extraem dados do Request
+--------------------------------------
 
+.. versionadded:: 0.19.1
+
+O Asyncworker fornece alguns typehints que são inteligentes o bastante para extrairem dados do request e passar esses dados para o handler sendo chamado.
+
+Todos os typhints são genéricos e recebem apenas **um** parametro. Os typehitns disponíveis são:
+
+- ``PathParam[T]``
+
+Onde ``T`` é o tipo do dado que será extraído do request. Para usar esses typehints basta anotar os parametros do seu handler com o tipo necessário. Como o seu handler passará a receber um argumento do tipo ``PathParam`` (ou qualquer outro typehint inteligente) será necessáio, de alguma forma, extrair o valor real de dentro desse objeto.
+
+Todos os typehints fornecidos pelo asyncworker possuem o método ``unpack()``. Esse  método serve justamente para extrair o valor que foi lido do request.
+
+Note que esse método é uma corotina. Ser corotina permite que o asyncworker faça "lazy parsing" do request. Isso significa que, em alguns casos, o request só será efetivamente lido quando você chamar ``await unpack()``. Isso é especialmente útil quando falamos de Request Bodies que são grandes.
+
+Receber uma instância da classe mencionada na assinatura do handler (em vez de receber diretamente o valor vindo do request) permite que o seu código seja validado estaticamente de forma correta.
+
+Aqui tem um exemplo simples de como usar o :ref:`PathParam[T] <handler-path-param>`.
 
 Recebendo parâmetros vindos do path do Request
-===============================================
+-----------------------------------------------
 
 .. _handler-path-param:
-.. versionadded:: 0.11.5
+.. versionadded:: 0.19.1
 
-É possível receber em seu handler parametros definidos no path da requisição. Isso é feito través do decorator :py:func:`asyncworker.http.decorators.parse_path`.
+É possível receber em seu handler parametros definidos no path da requisição. Isso é feito través do typehint :py:class:`asyncworker.http.types.PathParam`.
 
-Quando decoramos nosso handler com esse decorator instruímos o asyncworker a tentar extrair parametros do path e passar para nosso handler.
+Quando um handler menciona esse tipo em seus parametros isso faz o asyncworker tentar extrair parametros do path e passar para o handler.
 
 Importante notar que, primeiro o asyncworker vai procurar nosso parametro pelo nome e só depois tentará procurar o tipo.  Exemplo:
 
 .. code-block:: python
 
+  from asyncworker.http.types import PathParam
+
   @app.http.get(["/by_id/{_id}"])
-  @parse_path
-  async def by_id(_id: int):
-      return web.json_response({})
+  async def by_id(_id: PathParam[int]):
+      value = await _id.unpack()
+      return web.json_response({"_id": value})
 
-Nesse caso, como handler está dizendo que precisa de um parametro chamado ``_id`` temos que declarar um parametro de mesmo nome no path da Request. Depois que esse `match` for feito passaremos o valor recebido no path para o construtor do tipo definido na assinatura do handler.
+Nesse caso, como handler está dizendo que precisa de um parametro chamado ``_id`` temos que declarar um parametro de mesmo nome no path da Request. Depois que esse `match` for feito passaremos o valor recebido no path para o construtor do tipo definido na assinatura do handler, nesse caso ``PathParam``.
 
-Então nesse caso faremos um simples ``int(<valor>)``. Esse resultado será passado ao handler no parametro ``_id``, no momento da chamada.
+Para que seja possível lidar bem com linters (tipo ``mypy``) o que o asyncworker faz é de fato chamar o handler passando uma instância de ``PathParam``. Essa intância tem, internamente, o valor real que foi passdo no path do request, já convertido para o tipo correto. Nesse caso aqui um ``int``.
 
 Importante notar que só serão passados ao handler os parametros que estão definidos na assinatura. Então se seu path recebe dois parametros e seu handler só se interessa por um deles, basta declarar na assinatura do handler o parametro que você quer receber.
-
-
-Essa implementação ainda é experimental e servirá de fundação para uma implementação mais complexa, talvez com tipos mais complexos e sem a necessidade de passar o decorator explicitamente.
-
-**Impotante**: Esse decorator deve sempre ser o decorator "mais próximo" da função real, ou seja, deve ser sempre o primeiro decorator, logo acima da função sendo decorada. Isso porque o ``parse_path`` olha para a assinatura do handler sendo decorado. Se ele não for o primeiro decorator ele não vai receber o handler real como parâmetro e sim receberá o retorno de outro decorator, que já não reflete assinatura original do handler.

--- a/docs-src/userguide/handlers/http/index.rst
+++ b/docs-src/userguide/handlers/http/index.rst
@@ -31,7 +31,6 @@ Podemos fazer o que for preciso para extrair dele as informações que precisarm
 
 .. toctree::
    :maxdepth: 5
-   :titlesonly:
 
    doc.rst
    exposed-metrics.rst

--- a/examples/http_api.py
+++ b/examples/http_api.py
@@ -1,9 +1,7 @@
 from aiohttp import web
 
 from asyncworker import App
-from asyncworker.http.decorators import parse_path
 from asyncworker.http.types import PathParam
-from asyncworker.http.wrapper import RequestWrapper
 
 app = App()
 
@@ -13,21 +11,17 @@ async def handler():
     return web.json_response({})
 
 
-# @app.http.get(["/by_id/{_id}/other/{value}"])
-# @parse_path
-# async def by_id(_id: int, value: int):
-#    return web.json_response({"url-param-value": f"{_id}, {value}"})
-
-
-# @app.http.get(["/one-param"])
-# async def one_param(r: RequestWrapper):
-#    return web.json_response(dict(r.http_request.query))
-
-
-@app.http.get(["/path/{id}/accounts"])
-async def _accounts(id: PathParam[int]):
-    _id: int = id.unpack()
+@app.http.get(["/path/{id}/accounts/{foo}"])
+async def _accounts(id: PathParam[int], foo: PathParam[str]):
+    _id: int = await id.unpack()
     return web.json_response({"account_id": _id})
+
+
+@app.http.get(["/users/{_id}/books/{shelf}"])
+async def _user_books(_id: PathParam[int], shelf: PathParam[int]):
+    _id_value: int = await _id.unpack()
+    shelf_id = await shelf.unpack()
+    return web.json_response({"user_id": _id_value, "shelf_id": shelf_id})
 
 
 app.run()

--- a/examples/http_api.py
+++ b/examples/http_api.py
@@ -2,6 +2,7 @@ from aiohttp import web
 
 from asyncworker import App
 from asyncworker.http.decorators import parse_path
+from asyncworker.http.types import PathParam
 from asyncworker.http.wrapper import RequestWrapper
 
 app = App()
@@ -12,15 +13,21 @@ async def handler():
     return web.json_response({})
 
 
-@app.http.get(["/by_id/{_id}/other/{value}"])
-@parse_path
-async def by_id(_id: int, value: int):
-    return web.json_response({"url-param-value": f"{_id}, {value}"})
+# @app.http.get(["/by_id/{_id}/other/{value}"])
+# @parse_path
+# async def by_id(_id: int, value: int):
+#    return web.json_response({"url-param-value": f"{_id}, {value}"})
 
 
-@app.http.get(["/one-param"])
-async def one_param(r: RequestWrapper):
-    return web.json_response(dict(r.http_request.query))
+# @app.http.get(["/one-param"])
+# async def one_param(r: RequestWrapper):
+#    return web.json_response(dict(r.http_request.query))
+
+
+@app.http.get(["/path/{id}/accounts"])
+async def _accounts(id: PathParam[int]):
+    _id: int = id.unpack()
+    return web.json_response({"account_id": _id})
 
 
 app.run()

--- a/tests/http/test_pathparam_type.py
+++ b/tests/http/test_pathparam_type.py
@@ -54,6 +54,20 @@ class TestPathParamTypeHint(TestCase):
             data = await resp.json()
             self.assertEqual({"n": 42, "other": "name"}, data)
 
+    async def test_multiple_params_of_the_same_type(self):
+        @self.app.http.get(["/num/{n}/{other}"])
+        async def _get(other: PathParam[int], n: PathParam[int]):
+            return json_response(
+                {"n": await n.unpack(), "other": await other.unpack()}
+            )
+
+        async with HttpClientContext(self.app) as client:
+            resp = await client.get("/num/42/99")
+            self.assertEqual(HTTPStatus.OK, resp.status)
+
+            data = await resp.json()
+            self.assertEqual({"n": 42, "other": 99}, data)
+
     async def test_handler_receives_path_param_and_request_wrapper(self):
         @self.app.http.get(["/num/{n}/{other}"])
         async def _get(

--- a/tests/http/test_pathparam_type.py
+++ b/tests/http/test_pathparam_type.py
@@ -1,0 +1,166 @@
+from http import HTTPStatus
+
+from aiohttp.test_utils import make_mocked_request
+from aiohttp.web import json_response
+from asynctest import TestCase
+
+from asyncworker import App
+from asyncworker.decorators import wraps
+from asyncworker.http.types import PathParam
+from asyncworker.http.wrapper import RequestWrapper
+from asyncworker.routes import call_http_handler
+from asyncworker.testing import HttpClientContext
+from asyncworker.types.registry import TypesRegistry
+from asyncworker.types.resolver import ArgResolver
+
+
+class TestPathParamTypeHint(TestCase):
+    async def setUp(self):
+        self.app = App()
+
+    async def test_parse_simple_int(self):
+        @self.app.http.get(["/num/{n}"])
+        async def _get(n: PathParam[int]):
+            return json_response({"n": n.unpack()})
+
+        async with HttpClientContext(self.app) as client:
+            resp = await client.get("/num/42")
+            self.assertEqual(HTTPStatus.OK, resp.status)
+            data = await resp.json()
+            self.assertEqual({"n": 42}, data)
+
+    async def test_one_param_mismatched_type(self):
+        @self.app.http.get(["/num/{n}"])
+        async def _get(n: PathParam[int]):
+            return json_response({"n": n.unpack()})
+
+        async with HttpClientContext(self.app) as client:
+            resp = await client.get("/num/abc")
+            self.assertEqual(HTTPStatus.NOT_FOUND, resp.status)
+
+    async def test_multiple_params(self):
+        @self.app.http.get(["/num/{n}/{other}"])
+        async def _get(other: PathParam[str], n: PathParam[int]):
+            return json_response({"n": n.unpack(), "other": other.unpack()})
+
+        async with HttpClientContext(self.app) as client:
+            resp = await client.get("/num/42/name")
+            self.assertEqual(HTTPStatus.OK, resp.status)
+
+            data = await resp.json()
+            self.assertEqual({"n": 42, "other": "name"}, data)
+
+    async def test_handler_receives_path_param_and_request_wrapper(self):
+        @self.app.http.get(["/num/{n}/{other}"])
+        async def _get(
+            other: PathParam[str], n: PathParam[int], wrapper: RequestWrapper
+        ):
+            return json_response(
+                {
+                    "n": n.unpack(),
+                    "other": other.unpack(),
+                    "path": wrapper.http_request.path,
+                }
+            )
+
+        async with HttpClientContext(self.app) as client:
+            resp = await client.get("/num/42/name")
+            self.assertEqual(HTTPStatus.OK, resp.status)
+
+            data = await resp.json()
+            self.assertEqual(
+                {"n": 42, "other": "name", "path": "/num/42/name"}, data
+            )
+
+    async def test_path_param_complex_type(self):
+        class MyObject:
+            def __init__(self, val: str):
+                self.value = val
+
+        @self.app.http.get(["/num/{other}"])
+        async def _get(other: PathParam[MyObject]):
+            name = other.unpack().value
+            return json_response({"name": name})
+
+        async with HttpClientContext(self.app) as client:
+            resp = await client.get("/num/name")
+            self.assertEqual(HTTPStatus.OK, resp.status)
+
+            data = await resp.json()
+            self.assertEqual({"name": "name"}, data)
+
+    async def test_path_param_from_request(self):
+        request = make_mocked_request("GET", "/num/42", match_info={"n": "42"})
+        wrapper = RequestWrapper(
+            http_request=request, types_registry=TypesRegistry()
+        )
+        path_param_instance = await PathParam.from_request(
+            wrapper, arg_name="n", arg_type=int
+        )
+        self.assertEqual(42, path_param_instance.unpack())
+
+    async def test_aiohttp_fake_request(self):
+        async def _get(n: PathParam[int]):
+            return n.unpack()
+
+        request = make_mocked_request("GET", "/num/42", match_info={"n": "42"})
+        request_wrapper = RequestWrapper(
+            http_request=request, types_registry=TypesRegistry()
+        )
+        resolver = ArgResolver(request_wrapper.types_registry)
+
+        async def _resolve_wrap(_handler, request_wrapper):
+            p: PathParam[int] = PathParam(10)
+            request_wrapper.types_registry.set(p, PathParam[int])
+            return await resolver.wrap(_handler)
+
+        self.assertEqual(10, await _resolve_wrap(_get, request_wrapper))
+
+    async def test_with_custom_decorator(self):
+        def _deco(handler):
+            @wraps(handler)
+            async def _wrap(r: RequestWrapper, **_):
+                r.types_registry.set(42, type_definition=int)
+                return await call_http_handler(r, handler)
+
+            return _wrap
+
+        @self.app.http.get(["/path/{n}"])
+        @_deco
+        async def _path(r: RequestWrapper, n: PathParam[int], p: int):
+            return json_response({"n": n.unpack(), "p": p})
+
+        async with HttpClientContext(self.app) as client:
+            resp = await client.get("/path/10")
+            self.assertEqual(HTTPStatus.OK, resp.status)
+            data = await resp.json()
+            self.assertEqual({"n": 10, "p": 42}, data)
+
+    async def test_with_multiple_custom_decorator(self):
+        def _deco_1(handler):
+            @wraps(handler)
+            async def _wrap(r: RequestWrapper, **_):
+                r.types_registry.set(42, type_definition=int)
+                return await call_http_handler(r, handler)
+
+            return _wrap
+
+        def _deco_2(handler):
+            @wraps(handler)
+            async def _wrap(r: RequestWrapper, **_):
+                r.types_registry.set("value", type_definition=str)
+                return await call_http_handler(r, handler)
+
+            return _wrap
+
+        @self.app.http.get(["/path/{n}"])
+        @_deco_2
+        @_deco_1
+        async def _path(r: RequestWrapper, n: PathParam[int], p: int, v: str):
+            return json_response({"n": n.unpack(), "p": p, "v": "value"})
+
+        async with HttpClientContext(self.app) as client:
+            resp = await client.get("/path/10")
+            self.assertEqual(HTTPStatus.OK, resp.status)
+            data = await resp.json()
+            self.assertEqual({"n": 10, "p": 42, "v": "value"}, data)

--- a/tests/http/test_pathparam_type.py
+++ b/tests/http/test_pathparam_type.py
@@ -197,14 +197,10 @@ class TestPathParamTypeHint(TestCase):
 
         self.assertTrue(original_qualname in exc.exception.args[0])
         self.assertTrue(
-            "<class 'asyncworker.http.types.PathParam'> must be Generic Type"
-            in exc.exception.args[0]
+            "asyncworker.http.types.PathParam" in exc.exception.args[0]
         )
 
-        self.assertTrue(
-            "<class 'asyncworker.http.types.PathParam'>[T]"
-            in exc.exception.args[0]
-        )
+        self.assertTrue("must be Generic Type" in exc.exception.args[0])
 
     async def test_exceptions_must_show_original_handler_name(self):
         """

--- a/tests/http/test_pathparam_type.py
+++ b/tests/http/test_pathparam_type.py
@@ -38,7 +38,7 @@ class TestPathParamTypeHint(TestCase):
 
         async with HttpClientContext(self.app) as client:
             resp = await client.get("/num/abc")
-            self.assertEqual(HTTPStatus.NOT_FOUND, resp.status)
+            self.assertEqual(HTTPStatus.BAD_REQUEST, resp.status)
 
     async def test_multiple_params(self):
         @self.app.http.get(["/num/{n}/{other}"])
@@ -183,7 +183,13 @@ class TestPathParamTypeHint(TestCase):
 
         self.assertTrue(original_qualname in exc.exception.args[0])
         self.assertTrue(
-            "PathParam must be Generic Type" in exc.exception.args[0]
+            "<class 'asyncworker.http.types.PathParam'> must be Generic Type"
+            in exc.exception.args[0]
+        )
+
+        self.assertTrue(
+            "<class 'asyncworker.http.types.PathParam'>[T]"
+            in exc.exception.args[0]
         )
 
     async def test_exceptions_must_show_original_handler_name(self):
@@ -210,6 +216,3 @@ class TestPathParamTypeHint(TestCase):
             self.app.http.get(["/path/{n}"])(_deco_2(my_handler))
 
         self.assertTrue(original_qualname in exc.exception.args[0])
-        self.assertTrue(
-            "PathParam must be Generic Type" in exc.exception.args[0]
-        )

--- a/tests/http/test_pathparam_type.py
+++ b/tests/http/test_pathparam_type.py
@@ -195,7 +195,7 @@ class TestPathParamTypeHint(TestCase):
 
             app.http.get(["/path/{n}"])(_path)
 
-        self.assertTrue(original_qualname in exc.exception.args[0])
+        self.assertIn(original_qualname, exc.exception.args[0])
         self.assertTrue(
             "asyncworker.http.types.PathParam" in exc.exception.args[0]
         )
@@ -225,4 +225,4 @@ class TestPathParamTypeHint(TestCase):
 
             self.app.http.get(["/path/{n}"])(_deco_2(my_handler))
 
-        self.assertTrue(original_qualname in exc.exception.args[0])
+        self.assertIn(original_qualname, exc.exception.args[0])

--- a/tests/http/test_pathparam_type.py
+++ b/tests/http/test_pathparam_type.py
@@ -137,7 +137,7 @@ class TestPathParamTypeHint(TestCase):
     async def test_with_custom_decorator(self):
         def _deco(handler):
             @wraps(handler)
-            async def _wrap(r: RequestWrapper, **_):
+            async def _wrap(r: RequestWrapper):
                 r.types_registry.set(42, type_definition=int)
                 return await call_http_handler(r, handler)
 
@@ -157,7 +157,7 @@ class TestPathParamTypeHint(TestCase):
     async def test_with_multiple_custom_decorator(self):
         def _deco_1(handler):
             @wraps(handler)
-            async def _wrap(r: RequestWrapper, **_):
+            async def _wrap(r: RequestWrapper):
                 r.types_registry.set(42, type_definition=int)
                 return await call_http_handler(r, handler)
 
@@ -165,7 +165,7 @@ class TestPathParamTypeHint(TestCase):
 
         def _deco_2(handler):
             @wraps(handler)
-            async def _wrap(r: RequestWrapper, **_):
+            async def _wrap(r: RequestWrapper):
                 r.types_registry.set("value", type_definition=str)
                 return await call_http_handler(r, handler)
 
@@ -214,7 +214,7 @@ class TestPathParamTypeHint(TestCase):
 
         def _deco_2(handler):
             @wraps(handler)
-            async def _wrap(r: RequestWrapper, **_):
+            async def _wrap(r: RequestWrapper):
                 r.types_registry.set("value", type_definition=str)
                 return await call_http_handler(r, handler)
 

--- a/tests/http/test_pathparam_type.py
+++ b/tests/http/test_pathparam_type.py
@@ -39,6 +39,10 @@ class TestPathParamTypeHint(TestCase):
         async with HttpClientContext(self.app) as client:
             resp = await client.get("/num/abc")
             self.assertEqual(HTTPStatus.BAD_REQUEST, resp.status)
+            data = await resp.text()
+            self.assertEqual(
+                "invalid literal for int() with base 10: 'abc'", data
+            )
 
     async def test_multiple_params(self):
         @self.app.http.get(["/num/{n}/{other}"])

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -53,6 +53,10 @@ class TestWrapsDecorator(TestCase):
         self.assertEqual(
             get_handler_original_typehints(final_func), {"q": int, "b": bool}
         )
+        self.assertEqual(
+            "TestWrapsDecorator.test_with_one_first_decorator.<locals>._func",
+            final_func.asyncworker_original_qualname,
+        )
 
     async def test_with_two_second_decorators(self):
         @handler_register
@@ -66,6 +70,11 @@ class TestWrapsDecorator(TestCase):
         self.assertEqual(
             get_handler_original_typehints(final_func),
             {"other": int, "integer": int, "feature": bool},
+        )
+
+        self.assertEqual(
+            "TestWrapsDecorator.test_with_two_second_decorators.<locals>._func",
+            final_func.asyncworker_original_qualname,
         )
 
     async def test_with_three_decorators(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -3,7 +3,7 @@ from asynctest import TestCase
 from asyncworker.decorators import wraps
 from asyncworker.types.registry import TypesRegistry
 from asyncworker.types.resolver import ArgResolver
-from asyncworker.utils import get_handler_original_typehints
+from asyncworker.typing import get_handler_original_typehints
 
 
 def handler_register(func):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,7 @@ from unittest.mock import patch, Mock
 import asynctest as asynctest
 from freezegun import freeze_time
 
-from asyncworker.decorators import wraps
-from asyncworker.utils import get_handler_original_typehints, Timeit
+from asyncworker.utils import Timeit
 from tests.utils import typed_any
 
 
@@ -152,38 +151,3 @@ class TypedAnyTests(unittest.TestCase):
         self.assertNotEqual(5, typed_any(str))
         self.assertNotEqual("abc", typed_any(int))
         self.assertNotEqual(ValueError(), typed_any(Exception))
-
-
-class TestGetOriginalHandlerTypeHints(asynctest.TestCase):
-    async def test_does_not_have_attribute(self):
-        def func(a: int, b: bool):
-            pass
-
-        self.assertEqual(
-            get_handler_original_typehints(func), {"a": int, "b": bool}
-        )
-        self.assertFalse(hasattr(func, "asyncworker_original_annotations"))
-
-    async def test_has_attribute(self):
-        def simple_deco(handler):
-            @wraps(handler)
-            async def _wrapper():
-                return await handler()
-
-            return _wrapper
-
-        def other_deco(handler):
-            @wraps(handler)
-            async def _wrap():
-                return get_handler_original_typehints(handler)
-
-            return _wrap
-
-        @other_deco
-        @simple_deco
-        async def handler(a: bool, s: str):
-            return 42
-
-        result = await handler()
-        self.assertEqual(result, {"a": bool, "s": str})
-        self.assertTrue(hasattr(handler, "asyncworker_original_annotations"))

--- a/tests/types/test_arg_resolver.py
+++ b/tests/types/test_arg_resolver.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Tuple
 
 from asynctest import TestCase
 

--- a/tests/types/test_registry.py
+++ b/tests/types/test_registry.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Generic, TypeVar
 
 from asynctest import TestCase
 
@@ -59,3 +59,53 @@ class TypesRegistryTest(TestCase):
 
         self.registry.set(42, param_name="obj_id")
         self.assertEqual(None, self.registry.get(str, param_name="obj_id"))
+
+    async def test_aceita_tipo_generico_um_arg_tipo_simples(self):
+        T = TypeVar("T")
+
+        class MyGeneric(Generic[T]):
+            def __init__(self, val: T) -> None:
+                self._val: T = val
+
+        v: MyGeneric[int] = MyGeneric(10)
+        self.registry.set(v, MyGeneric[int])
+        self.assertEqual(v, self.registry.get(MyGeneric[int]))
+
+    async def test_aceita_generico_dois_args(self):
+        T = TypeVar("T")
+        P = TypeVar("P")
+
+        class MyGenericDoisArgs(Generic[T, P]):
+            def __init__(self, val: T) -> None:
+                self._val: T = val
+
+        v: MyGenericDoisArgs[int, str] = MyGenericDoisArgs(10)
+        self.registry.set(v, MyGenericDoisArgs[int, str])
+        self.assertEquals(v, self.registry.get(MyGenericDoisArgs[int, str]))
+
+    async def test_generico_dois_args_ordem_importa(self):
+        T = TypeVar("T")
+        P = TypeVar("P")
+
+        class MyGenericDoisArgs(Generic[T, P]):
+            def __init__(self, val: T) -> None:
+                self._val: T = val
+
+        v: MyGenericDoisArgs[int, str] = MyGenericDoisArgs(10)
+        self.registry.set(v, MyGenericDoisArgs[int, str])
+        self.assertIsNone(self.registry.get(MyGenericDoisArgs[str, int]))
+
+    async def test_generico_um_arg_tipo_complexo(self):
+
+        T = TypeVar("T")
+
+        class MyGeneric(Generic[T]):
+            def __init__(self, val: T) -> None:
+                self._val: T = val
+
+        class OtherObject:
+            pass
+
+        v: MyGeneric[OtherObject] = MyGeneric(OtherObject())
+        self.registry.set(v, MyGeneric[OtherObject])
+        self.assertEquals(v, self.registry.get(MyGeneric[OtherObject]))

--- a/tests/typing/test_typing_functions.py
+++ b/tests/typing/test_typing_functions.py
@@ -2,7 +2,12 @@ from typing import Generic, TypeVar
 
 from asynctest import TestCase
 
-from asyncworker.typing import get_args, get_origin
+from asyncworker.decorators import wraps
+from asyncworker.typing import (
+    get_args,
+    get_origin,
+    get_handler_original_typehints,
+)
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -42,3 +47,38 @@ class TestTypingFunctions(TestCase):
 
     async def test_get_origin_concrete_type(self):
         self.assertIsNone(get_origin(MyObject))
+
+
+class TestGetOriginalHandlerTypeHints(TestCase):
+    async def test_does_not_have_attribute(self):
+        def func(a: int, b: bool):
+            pass
+
+        self.assertEqual(
+            get_handler_original_typehints(func), {"a": int, "b": bool}
+        )
+        self.assertFalse(hasattr(func, "asyncworker_original_annotations"))
+
+    async def test_has_attribute(self):
+        def simple_deco(handler):
+            @wraps(handler)
+            async def _wrapper():
+                return await handler()
+
+            return _wrapper
+
+        def other_deco(handler):
+            @wraps(handler)
+            async def _wrap():
+                return get_handler_original_typehints(handler)
+
+            return _wrap
+
+        @other_deco
+        @simple_deco
+        async def handler(a: bool, s: str):
+            return 42
+
+        result = await handler()
+        self.assertEqual(result, {"a": bool, "s": str})
+        self.assertTrue(hasattr(handler, "asyncworker_original_annotations"))

--- a/tests/typing/test_typing_functions.py
+++ b/tests/typing/test_typing_functions.py
@@ -4,6 +4,7 @@ from asynctest import TestCase
 
 from asyncworker.decorators import wraps
 from asyncworker.typing import (
+    is_base_type,
     get_args,
     get_origin,
     get_handler_original_typehints,
@@ -82,3 +83,19 @@ class TestGetOriginalHandlerTypeHints(TestCase):
         result = await handler()
         self.assertEqual(result, {"a": bool, "s": str})
         self.assertTrue(hasattr(handler, "asyncworker_original_annotations"))
+
+
+class TestIsBaseType(TestCase):
+    async def test_is_base_when_generic(self):
+        def _func(b: MyGeneric[int]):
+            pass
+
+        _type = get_handler_original_typehints(_func)
+        self.assertTrue(is_base_type(_type["b"], MyGeneric))
+
+    async def test_is_base_when_not_generic(self):
+        def _func(b: MyGeneric):
+            pass
+
+        _type = get_handler_original_typehints(_func)
+        self.assertTrue(is_base_type(_type["b"], MyGeneric))

--- a/tests/typing/test_typing_functions.py
+++ b/tests/typing/test_typing_functions.py
@@ -101,6 +101,13 @@ class TestIsBaseType(TestCase):
         _type = get_handler_original_typehints(_func)
         self.assertTrue(is_base_type(_type["b"], MyGeneric))
 
+    async def test_is_base_when_primitive_type(self):
+        def _func(b: int):
+            pass
+
+        _type = get_handler_original_typehints(_func)
+        self.assertFalse(is_base_type(_type["b"], MyGeneric))
+
 
 class TestHandlerGetOriginalQualname(TestCase):
     async def test_get_qualname_no_decorators(self):

--- a/tests/typing/test_typing_functions.py
+++ b/tests/typing/test_typing_functions.py
@@ -1,0 +1,44 @@
+from typing import Generic, TypeVar
+
+from asynctest import TestCase
+
+from asyncworker.typing import get_args, get_origin
+
+T = TypeVar("T")
+K = TypeVar("K")
+
+
+class MyGeneric(Generic[T]):
+    pass
+
+
+class MyGenericTwoArguments(Generic[K, T]):
+    pass
+
+
+class MyObject:
+    pass
+
+
+class TestTypingFunctions(TestCase):
+    async def setUp(self):
+        pass
+
+    async def test_get_args_generic_type(self):
+        self.assertEqual((MyObject,), get_args(MyGeneric[MyObject]))
+        self.assertEqual(
+            (int, MyObject), get_args(MyGenericTwoArguments[int, MyObject])
+        )
+
+    async def test_get_args_concrete_type(self):
+        self.assertIsNone(get_args(MyObject))
+
+    async def test_get_origin_generic_type(self):
+        self.assertEqual(MyGeneric, get_origin(MyGeneric[MyObject]))
+        self.assertEqual(
+            MyGenericTwoArguments,
+            get_origin(MyGenericTwoArguments[int, MyObject]),
+        )
+
+    async def test_get_origin_concrete_type(self):
+        self.assertIsNone(get_origin(MyObject))

--- a/tests/typing/test_typing_functions.py
+++ b/tests/typing/test_typing_functions.py
@@ -101,12 +101,19 @@ class TestIsBaseType(TestCase):
         _type = get_handler_original_typehints(_func)
         self.assertTrue(is_base_type(_type["b"], MyGeneric))
 
-    async def test_is_base_when_primitive_type(self):
+    async def test_is_base_when_arg_generic_base_primitive(self):
         def _func(b: MyGeneric):
             pass
 
         _type = get_handler_original_typehints(_func)
         self.assertFalse(is_base_type(_type["b"], int))
+
+    async def test_is_base_when_arg_primitive_base_generic(self):
+        def _func(b: int):
+            pass
+
+        _type = get_handler_original_typehints(_func)
+        self.assertFalse(is_base_type(_type["b"], MyGeneric))
 
 
 class TestHandlerGetOriginalQualname(TestCase):

--- a/tests/typing/test_typing_functions.py
+++ b/tests/typing/test_typing_functions.py
@@ -102,11 +102,11 @@ class TestIsBaseType(TestCase):
         self.assertTrue(is_base_type(_type["b"], MyGeneric))
 
     async def test_is_base_when_primitive_type(self):
-        def _func(b: int):
+        def _func(b: MyGeneric):
             pass
 
         _type = get_handler_original_typehints(_func)
-        self.assertFalse(is_base_type(_type["b"], MyGeneric))
+        self.assertFalse(is_base_type(_type["b"], int))
 
 
 class TestHandlerGetOriginalQualname(TestCase):


### PR DESCRIPTION
Esse PR implementa a possibilidade de um handler receber parametros do path do request. Ele também deprecia, oficialmente, o uso do decorator `@parse_path`.

Efetivamente essa implementação permite transformar um handler assim:

```python
@app.http.get(["/by_id/{_id}"])
@parse_path
async def by_id(_id: int):
    return web.json_response({"_id": _id})
```

Em um handler assim:

```python
from asyncworker.http.types import PathParam

@app.http.get(["/by_id/{_id}"])
async def by_id(_id: PathParam[int]):
    value = await _id.unpack()
    return web.json_response({"_id": value})
```

Mais detalhes sobre a ideia por traś dessa implementação estão no #114. E o racional por trás do `.unpack()` está aqui: [#114 comment](https://github.com/b2wdigital/async-worker/issues/114#issuecomment-573776467)


Closes #136 

# Tarefas

- [x] Melhorar a annotation do `PathParamSpec` para que ele receba mais do que `base: Type` e receba algo que ele saiba que implemente uma interface que será comum a todos os typehints que pegarão dados do request
- [x] Pensar nessa interface comum. Atualmente a interface está assim: `async def from_request(request: RequestWrapper, arg_name: str, arg_type: Type)` mas seria legal que todos os typehints pudessem usar essa assinatura.
- [x] Criar uma base class de onde todos esses typehints herdarão. Essa classe forneceria a inteface completa:
     - Construtor, que dirá como esses typehints receberão o valor  "bruto" do request e transformarão em valores parseados
     - Método para receber uma cópia do request qu está sendo atendido (`from_request(...)`) e retornar uma instância do typehint com o valor guardado dentro
     - Método `async def unpack()` para fornecer acesso ao valor que está guardado internamente. A ideia desse método ser `async` é poder fazermos "lazy parsing", ou seja, se o seu handler recebe um parametro do request mas nem sempr o usa, o request nem seria lido até que você chame `await *.unpack()`. Isso é especialmente útil para requests com Body.  
- [x] Melhorar a extração do parametro o typehint genérico, aqui nesse draft estamos apenas usando `get_args(base)[0]`. Melhorar essa parte e se possível validar melhor.
- [x] Decidir se um handler declarado como `(_id: PathParam[int])` quando recebe um `GET /list/abc` retorna 404 ou 400. Esse teste está atualmente quebrando pois obviamente `int("abc")` é um erro. =D
    - Acho que vale a pena retorna BAD_REQUEST pois isso não deixa de ser um erro de validação. Seria muito estranho e não-intuitivo retornar 404.
- [x] Ajustar o teste que confirma que um handler qur recebe `(a: PathParam[int], b: PathParam[int])` não está recebendo os dois valores e sim recebe um só. Curiosamente o problema não acontece quando o handler é decorado com `@parse_path` e recebe `(a: int, b: int)`. https://github.com/b2wdigital/async-worker/pull/269/commits/49666bf10040fa927ec7d08bcad84075d4f21d20 Acabou que bastou corrigir o TypesRegistry.
- [x] Corrigir a implementação do `is_base_type()`. Quando o `or` precisa olhar a segunda parte (`issubclass()`) temos um problmas quando temos handlers que declaram tipos básicos (`int`, `str`, etc).
    Temos que pensar em uma forma mais esperta de detectar se um typehint do handler é um dos tipos que estamos implementando nesse PR. Temos que poder detectar tanto `(a: PathParam)` quando `(a: PathParam[T])`.
- [x] Adicionar validação para quando um argumento é declarado mas não é passado no request.  Devemos retornar BAD_REQUEST. Isso aqui será a preparação para implementação do `(a: Optional[PathParam[int]])`;
- [x] Decidir onde é melhor fazer `raise` das Exceptions de HTTP. https://github.com/b2wdigital/async-worker/pull/269#issuecomment-826020307 ada55fc
- [x] Documentar como usar o `PathParam[T]`;
- [x] Depreciar oficialmente o decorator `@parse_path`;
    - Mencionar na notas de atualizaçãoq que o uso desse decorator está depreciado
- [x] Ajustar os exemplos para usar `PathParam[T]` em vez de `@parse_path`; 6c09a16
    - Mostrar exmplos com `PathParam` recebendo tipos diferentes (int e str) e tipos iguais (int e int)
- [x] Adicionar suporte a `PathParam[bool]`. Qualquer parametro `bool` está recebendo `True`, independente do valor recebido no request. 8238c0b